### PR TITLE
fix: Complete module rename from claude_code_cli to rustyclawd

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 authors.workspace = true
 
 [lib]
-name = "claude_code_cli"
+name = "rustyclawd"
 path = "src/lib.rs"
 
 [[bin]]

--- a/crates/cli/examples/verify_schemas.rs
+++ b/crates/cli/examples/verify_schemas.rs
@@ -1,7 +1,7 @@
 //! Standalone example to verify tool schemas have required fields
 
 // Examples need to reference the crate differently
-use claude_code_cli::tool_definitions::get_all_tool_definitions;
+use rustyclawd::tool_definitions::get_all_tool_definitions;
 use rustyclawd_core::client::ToolDefinition;
 
 fn main() {

--- a/crates/cli/src/checkpoint/mod.rs
+++ b/crates/cli/src/checkpoint/mod.rs
@@ -21,7 +21,7 @@
 //! # Usage
 //!
 //! ```rust,ignore
-//! use claude_code_cli::checkpoint::{Session, SessionSaver, SessionLoader, RestoreScope};
+//! use rustyclawd::checkpoint::{Session, SessionSaver, SessionLoader, RestoreScope};
 //!
 //! // Create a session
 //! let mut session = Session::new("my-session", 50);

--- a/crates/cli/src/plugins/mod.rs
+++ b/crates/cli/src/plugins/mod.rs
@@ -11,7 +11,7 @@
 //!
 //! # Example
 //! ```ignore
-//! use claude_code_cli::plugins::*;
+//! use rustyclawd::plugins::*;
 //!
 //! // Discover plugins
 //! let discovery = discovery::PluginDiscovery::new("./plugins");

--- a/crates/cli/src/terminal_guard.rs
+++ b/crates/cli/src/terminal_guard.rs
@@ -47,7 +47,7 @@ lazy_static::lazy_static! {
 /// # Example
 ///
 /// ```no_run
-/// use claude_code_cli::terminal_guard::{set_execution_context, ExecutionContext};
+/// use rustyclawd::terminal_guard::{set_execution_context, ExecutionContext};
 ///
 /// // At application startup in TUI mode
 /// set_execution_context(ExecutionContext::Tui);
@@ -80,7 +80,7 @@ pub fn get_execution_context() -> ExecutionContext {
 /// # Example
 ///
 /// ```no_run
-/// use claude_code_cli::terminal_guard::TerminalGuard;
+/// use rustyclawd::terminal_guard::TerminalGuard;
 ///
 /// # async fn execute_tool() -> anyhow::Result<()> {
 /// // Create guard - terminal state is suspended

--- a/crates/cli/tests/builtin_commands_real_data_tests.rs
+++ b/crates/cli/tests/builtin_commands_real_data_tests.rs
@@ -12,8 +12,8 @@
 #![allow(dead_code)]
 #![allow(clippy::manual_range_contains)]
 
-use claude_code_cli::commands::builtins::BuiltinCommands;
-use claude_code_cli::commands::parser::{Command, CommandParser};
+use rustyclawd::commands::builtins::BuiltinCommands;
+use rustyclawd::commands::parser::{Command, CommandParser};
 
 // Import the session state types from our tests
 // In real implementation, these would come from the main crate

--- a/crates/cli/tests/hooks_doc_tests.rs
+++ b/crates/cli/tests/hooks_doc_tests.rs
@@ -18,8 +18,8 @@
 #![allow(clippy::useless_vec)]
 #![allow(clippy::assertions_on_constants)]
 
-// Import from the parent CLI crate (uses lib name "claude_code_cli" from Cargo.toml)
-use claude_code_cli::hooks::{
+// Import from the parent CLI crate (uses lib name "rustyclawd" from Cargo.toml)
+use rustyclawd::hooks::{
     executor::HookExecutor,
     loader::HookLoader,
     registry::HookRegistry,

--- a/crates/cli/tests/plugin_integration_tests.rs
+++ b/crates/cli/tests/plugin_integration_tests.rs
@@ -13,8 +13,8 @@
 
 #![allow(clippy::useless_vec)]
 
-use claude_code_cli::hooks::registry::HookRegistry;
-use claude_code_cli::plugins::*;
+use rustyclawd::hooks::registry::HookRegistry;
+use rustyclawd::plugins::*;
 use std::collections::HashMap;
 use std::fs;
 use tempfile::TempDir;
@@ -25,7 +25,7 @@ fn create_test_plugin(root: &std::path::Path, plugin_id: &str) -> std::path::Pat
     fs::create_dir_all(&plugin_dir).unwrap();
 
     // Create plugin.json
-    let manifest = claude_code_cli::plugins::manifest::PluginManifest {
+    let manifest = rustyclawd::plugins::manifest::PluginManifest {
         id: plugin_id.to_string(),
         name: format!("{} Plugin", plugin_id),
         version: "1.0.0".to_string(),
@@ -127,7 +127,7 @@ async fn test_agent_discovery() {
 async fn test_mcp_proxy_registration() {
     let mut proxy = McpProxy::new();
 
-    let server_def = claude_code_cli::plugins::manifest::McpServerDefinition {
+    let server_def = rustyclawd::plugins::manifest::McpServerDefinition {
         id: "test-server".to_string(),
         name: "Test Server".to_string(),
         command: "node".to_string(),
@@ -157,7 +157,7 @@ async fn test_hooks_integration() {
     )
     .unwrap();
 
-    let hook_def = claude_code_cli::plugins::manifest::HookDefinition {
+    let hook_def = rustyclawd::plugins::manifest::HookDefinition {
         event: "PreToolUse".to_string(),
         handler: "test-hook.sh".to_string(),
     };
@@ -195,7 +195,7 @@ async fn test_plugin_manager_lifecycle() {
     .unwrap();
 
     // Create manifest with command and skill
-    let manifest = claude_code_cli::plugins::manifest::PluginManifest {
+    let manifest = rustyclawd::plugins::manifest::PluginManifest {
         id: "full-plugin".to_string(),
         name: "Full Plugin".to_string(),
         version: "1.0.0".to_string(),
@@ -203,13 +203,13 @@ async fn test_plugin_manager_lifecycle() {
         author: "Test".to_string(),
         license: "MIT".to_string(),
         main: "index.js".to_string(),
-        commands: vec![claude_code_cli::plugins::manifest::CommandDefinition {
+        commands: vec![rustyclawd::plugins::manifest::CommandDefinition {
             name: "test-cmd".to_string(),
             description: "Test command".to_string(),
             path: "commands/test.js".to_string(),
             args_schema: serde_json::json!({}),
         }],
-        skills: vec![claude_code_cli::plugins::manifest::SkillDefinition {
+        skills: vec![rustyclawd::plugins::manifest::SkillDefinition {
             id: "test-skill".to_string(),
             name: "Test Skill".to_string(),
             description: "A test skill".to_string(),
@@ -286,7 +286,7 @@ async fn test_plugin_with_agents() {
     )
     .unwrap();
 
-    let manifest = claude_code_cli::plugins::manifest::PluginManifest {
+    let manifest = rustyclawd::plugins::manifest::PluginManifest {
         id: "agent-plugin".to_string(),
         name: "Agent Plugin".to_string(),
         version: "1.0.0".to_string(),
@@ -297,7 +297,7 @@ async fn test_plugin_with_agents() {
         commands: vec![],
         skills: vec![],
         hooks: vec![],
-        agents: vec![claude_code_cli::plugins::manifest::AgentDefinition {
+        agents: vec![rustyclawd::plugins::manifest::AgentDefinition {
             id: "plugin-agent".to_string(),
             name: "Plugin Agent".to_string(),
             description: "Agent defined in plugin".to_string(),
@@ -366,7 +366,7 @@ async fn test_complete_plugin_system_workflow() {
     )
     .unwrap();
 
-    let manifest = claude_code_cli::plugins::manifest::PluginManifest {
+    let manifest = rustyclawd::plugins::manifest::PluginManifest {
         id: "workflow-plugin".to_string(),
         name: "Workflow Plugin".to_string(),
         version: "1.0.0".to_string(),
@@ -374,30 +374,30 @@ async fn test_complete_plugin_system_workflow() {
         author: "Test".to_string(),
         license: "MIT".to_string(),
         main: "index.js".to_string(),
-        commands: vec![claude_code_cli::plugins::manifest::CommandDefinition {
+        commands: vec![rustyclawd::plugins::manifest::CommandDefinition {
             name: "cmd".to_string(),
             description: "Test".to_string(),
             path: "commands/cmd.js".to_string(),
             args_schema: serde_json::json!({}),
         }],
-        skills: vec![claude_code_cli::plugins::manifest::SkillDefinition {
+        skills: vec![rustyclawd::plugins::manifest::SkillDefinition {
             id: "skill".to_string(),
             name: "Skill".to_string(),
             description: "Test".to_string(),
             path: "skills/skill.md".to_string(),
         }],
-        hooks: vec![claude_code_cli::plugins::manifest::HookDefinition {
+        hooks: vec![rustyclawd::plugins::manifest::HookDefinition {
             event: "PreToolUse".to_string(),
             handler: "hooks/hook.sh".to_string(),
         }],
-        agents: vec![claude_code_cli::plugins::manifest::AgentDefinition {
+        agents: vec![rustyclawd::plugins::manifest::AgentDefinition {
             id: "agent".to_string(),
             name: "Agent".to_string(),
             description: "Test".to_string(),
             path: "agents/agent.md".to_string(),
             model: None,
         }],
-        mcp_servers: vec![claude_code_cli::plugins::manifest::McpServerDefinition {
+        mcp_servers: vec![rustyclawd::plugins::manifest::McpServerDefinition {
             id: "mcp".to_string(),
             name: "MCP".to_string(),
             command: "node".to_string(),

--- a/crates/cli/tests/slash_commands_test.rs
+++ b/crates/cli/tests/slash_commands_test.rs
@@ -1,4 +1,4 @@
-use claude_code_cli::commands::SlashCommands;
+use rustyclawd::commands::SlashCommands;
 
 #[tokio::test]
 async fn test_slash_commands_discovery() {

--- a/crates/cli/tests/tool_executor_tests.rs
+++ b/crates/cli/tests/tool_executor_tests.rs
@@ -1,4 +1,4 @@
-use claude_code_cli::tool_executor::execute_tool;
+use rustyclawd::tool_executor::execute_tool;
 use serde_json::json;
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #26 by renaming all 28 remaining references.

**Verification**:
- 0 references to claude_code_cli remain
- All tests pass
- Clippy passes with strict -D warnings

Ready to merge\!