### PR TITLE
feat: Replace ASCII pirate ship banner with orange crab in TUI (Issue #30)

### DIFF
--- a/crates/cli/src/tui/ui.rs
+++ b/crates/cli/src/tui/ui.rs
@@ -1,7 +1,7 @@
 //! TUI (Terminal User Interface) for RustyClawd
 //!
 //! A beautiful terminal interface using ratatui with:
-//! - Pirate ship banner
+//! - Orange crab banner (Unicode block art)
 //! - Scrollable message display area
 //! - Input area with prompt
 //! - Status bar
@@ -87,7 +87,7 @@ pub struct TuiState {
     scroll_offset: usize,
     /// Status message
     status: String,
-    /// Whether to show the pirate banner
+    /// Whether to show the orange crab banner
     show_banner: bool,
     /// Autocomplete suggestions (command_name, optional_hint)
     suggestions: Vec<(String, Option<String>)>,
@@ -406,9 +406,9 @@ impl TuiState {
     ) {
         let mut lines = Vec::new();
 
-        // Add pirate ship banner if enabled
+        // Add orange crab banner if enabled
         if show_banner && messages.is_empty() {
-            lines.extend(Self::render_pirate_ship());
+            lines.extend(Self::render_orange_crab());
             lines.push(Line::from(""));
             lines.push(Line::from(vec![
                 Span::styled(
@@ -457,49 +457,101 @@ impl TuiState {
         f.render_widget(messages_widget, area);
     }
 
-    /// Render pirate ship ASCII art
-    fn render_pirate_ship() -> Vec<Line<'static>> {
+    /// Render orange crab banner with Unicode block art
+    fn render_orange_crab() -> Vec<Line<'static>> {
+        // Beautiful orange crab made with Unicode block characters and emojis
         vec![
             Line::from(vec![Span::styled(
-                "                    |>",
+                "                      ╔═════════╗",
                 Style::default().fg(RUST_ORANGE),
             )]),
             Line::from(vec![Span::styled(
-                "                    |",
-                Style::default().fg(RUST_DARK),
+                "                      ║  🦀     ║",
+                Style::default().fg(RUST_ORANGE),
             )]),
             Line::from(vec![Span::styled(
-                "                   /|\\",
-                Style::default().fg(RUST_DARK),
+                "                      ║ RUSTY   ║",
+                Style::default().fg(RUST_LIGHT),
             )]),
             Line::from(vec![Span::styled(
-                "                  / | \\",
-                Style::default().fg(RUST_DARK),
+                "                      ║ CRAB    ║",
+                Style::default().fg(RUST_LIGHT),
             )]),
             Line::from(vec![Span::styled(
-                "                 /  |  \\",
-                Style::default().fg(RUST_DARK),
+                "                      ╠═════════╣",
+                Style::default().fg(RUST_ORANGE),
             )]),
             Line::from(vec![
-                Span::styled("                /   ", Style::default().fg(RUST_DARK)),
-                Span::styled("🦀", Style::default().fg(RUST_ORANGE)),
-                Span::styled("   \\", Style::default().fg(RUST_DARK)),
-            ]),
-            Line::from(vec![Span::styled(
-                "               /         \\",
-                Style::default().fg(RUST_DARK),
-            )]),
-            Line::from(vec![
-                Span::styled("        ", Style::default()),
-                Span::styled("🌊", Style::default().fg(Color::Cyan)),
-                Span::styled(" ~~~~~~~~~~~~~ ", Style::default().fg(Color::Blue)),
-                Span::styled("🌊", Style::default().fg(Color::Cyan)),
+                Span::styled("                    ", Style::default()),
+                Span::styled("███", Style::default().fg(RUST_ORANGE)),
+                Span::styled("     ", Style::default()),
+                Span::styled("███", Style::default().fg(RUST_ORANGE)),
             ]),
             Line::from(vec![
-                Span::styled("      ", Style::default()),
-                Span::styled("🌊🌊", Style::default().fg(Color::Cyan)),
-                Span::styled(" ~~~~~~~~~~~~~~~ ", Style::default().fg(Color::Blue)),
-                Span::styled("🌊🌊", Style::default().fg(Color::Cyan)),
+                Span::styled("                    ", Style::default()),
+                Span::styled("█", Style::default().fg(RUST_ORANGE)),
+                Span::styled(" ", Style::default()),
+                Span::styled("█", Style::default().fg(RUST_ORANGE)),
+                Span::styled("   ", Style::default()),
+                Span::styled("█", Style::default().fg(RUST_ORANGE)),
+                Span::styled(" ", Style::default()),
+                Span::styled("█", Style::default().fg(RUST_ORANGE)),
+            ]),
+            Line::from(vec![
+                Span::styled("                      ", Style::default()),
+                Span::styled("███", Style::default().fg(RUST_ORANGE)),
+            ]),
+            Line::from(vec![
+                Span::styled("                   ", Style::default()),
+                Span::styled("█████████", Style::default().fg(RUST_ORANGE)),
+            ]),
+            Line::from(vec![
+                Span::styled("                   ", Style::default()),
+                Span::styled("█", Style::default().fg(RUST_DARK)),
+                Span::styled("       ", Style::default()),
+                Span::styled("█", Style::default().fg(RUST_DARK)),
+            ]),
+            Line::from(vec![
+                Span::styled("                    ", Style::default()),
+                Span::styled("███████", Style::default().fg(RUST_DARK)),
+            ]),
+            Line::from(vec![
+                Span::styled("              ", Style::default()),
+                Span::styled("█", Style::default().fg(RUST_ORANGE)),
+                Span::styled(" ", Style::default()),
+                Span::styled("███", Style::default().fg(RUST_DARK)),
+                Span::styled("     ", Style::default()),
+                Span::styled("███", Style::default().fg(RUST_DARK)),
+                Span::styled(" ", Style::default()),
+                Span::styled("█", Style::default().fg(RUST_ORANGE)),
+            ]),
+            Line::from(vec![
+                Span::styled("              ", Style::default()),
+                Span::styled("█", Style::default().fg(RUST_ORANGE)),
+                Span::styled(" ", Style::default()),
+                Span::styled("█", Style::default().fg(RUST_DARK)),
+                Span::styled("   ", Style::default()),
+                Span::styled("█", Style::default().fg(RUST_DARK)),
+                Span::styled("   ", Style::default()),
+                Span::styled("█", Style::default().fg(RUST_DARK)),
+                Span::styled(" ", Style::default()),
+                Span::styled("█", Style::default().fg(RUST_ORANGE)),
+            ]),
+            Line::from(vec![
+                Span::styled("              ", Style::default()),
+                Span::styled("███████████", Style::default().fg(RUST_DARK)),
+            ]),
+            Line::from(vec![
+                Span::styled("             ", Style::default()),
+                Span::styled("█", Style::default().fg(RUST_ORANGE)),
+                Span::styled("  ", Style::default()),
+                Span::styled("█████████", Style::default().fg(RUST_DARK)),
+                Span::styled("  ", Style::default()),
+                Span::styled("█", Style::default().fg(RUST_ORANGE)),
+            ]),
+            Line::from(vec![
+                Span::styled("               ", Style::default()),
+                Span::styled("▀▀▀▀▀▀▀", Style::default().fg(RUST_DARK)),
             ]),
         ]
     }


### PR DESCRIPTION
## Summary
Replace the ASCII pirate ship banner with a beautiful orange crab banner using Unicode block art. This enhancement improves visual appeal while maintaining terminal compatibility (zero dependencies).

## Changes
- Implemented `render_orange_crab()` function with Unicode block art design
- Color-coded crab using project's RUST_ORANGE and RUST_DARK theme
- Updated `render_messages_area()` to call new banner renderer
- Updated documentation to reflect banner change

## Key Features
- Orange crab rendered with Unicode block characters (█ ▀ ╔ ║ ╠ ╣)
- Includes decorative "RUSTY CRAB" labeled box
- Works across all terminals (no special requirements)
- Maintains backward compatibility with `show_banner` flag
- Zero additional dependencies

## Testing
- Build: Successful
- Tests: All 133 pass
- Functionality: Banner toggles correctly with existing flag
- No breaking changes

## Related
Closes #30

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>