### PR TITLE
Add --prompt as alias for --print flag

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -38,7 +38,8 @@ struct Cli {
     command: Option<Commands>,
 
     /// Print mode - execute prompt and exit
-    #[arg(short = 'p', long = "print")]
+    /// (alias: --prompt)
+    #[arg(short = 'p', long = "print", alias = "prompt")]
     print_mode: bool,
 
     /// Continue from last session


### PR DESCRIPTION
## Summary
- Added `--prompt` as an alias for the `--print` flag
- Both flags work identically for one-shot execution mode
- Updated help text to document the alias

## Changes
- Modified `crates/cli/src/main.rs`:
  - Added `alias = "prompt"` to the `--print` flag definition
  - Updated doc comment to show "(alias: --prompt)"

## Test Results
- All existing tests pass
- Both `-p` and `--print` work as before
- New `--prompt` flag works identically
- Help text correctly documents the alias

## Closes
Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)