### PR TITLE
feat(tools): Unify skills and slash commands for /skill-name invocation

### DIFF
--- a/crates/tools/src/slash_command.rs
+++ b/crates/tools/src/slash_command.rs
@@ -1,9 +1,20 @@
 //! SlashCommand tool - Execute custom slash commands
 //!
+//! This tool unifies commands and skills, allowing both to be invoked via `/name` syntax.
+//! Like Claude Code, skills can be invoked as `/skill-name` in addition to `/command-name`.
+//!
+//! Resolution order:
+//! 1. `.claude/commands/{name}.md` - Traditional commands (highest priority)
+//! 2. `.claude/skills/{name}.md` - Direct skill file
+//! 3. `.claude/skills/{name}/SKILL.md` - Skill in subdirectory (uppercase SKILL.md)
+//! 4. `.claude/skills/{name}/skill.md` - Skill in subdirectory (lowercase skill.md)
+//! 5. `.claude/skills/{name}.yaml` - YAML skill file
+//!
 //! Demonstrates:
 //! - Command expansion and loading
 //! - File-based command definitions
 //! - Dynamic command discovery
+//! - Unified skill/command invocation
 
 use crate::{ToolContext, ToolEvent, ToolMetadata, ToolResult, ToolStream};
 use async_stream::stream;
@@ -30,6 +41,95 @@ pub struct SlashCommandOutput {
 
     /// Command name
     pub command_name: String,
+
+    /// Source of the command (command or skill)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<CommandSource>,
+
+    /// Path where the command/skill was found
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+/// Source type for the resolved command
+#[derive(Debug, Serialize, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum CommandSource {
+    /// Traditional command from .claude/commands/
+    Command,
+    /// Skill from .claude/skills/
+    Skill,
+}
+
+/// Resolution result containing content, source, and path
+struct Resolution {
+    content: String,
+    source: CommandSource,
+    path: String,
+}
+
+/// Get search paths for command/skill resolution
+fn get_search_paths(name: &str) -> Vec<(PathBuf, CommandSource)> {
+    vec![
+        // Commands first (backward compatible, highest priority)
+        (
+            PathBuf::from(format!(".claude/commands/{}.md", name)),
+            CommandSource::Command,
+        ),
+        // Skills - various formats
+        (
+            PathBuf::from(format!(".claude/skills/{}.md", name)),
+            CommandSource::Skill,
+        ),
+        (
+            PathBuf::from(format!(".claude/skills/{}/SKILL.md", name)),
+            CommandSource::Skill,
+        ),
+        (
+            PathBuf::from(format!(".claude/skills/{}/skill.md", name)),
+            CommandSource::Skill,
+        ),
+        (
+            PathBuf::from(format!(".claude/skills/{}.yaml", name)),
+            CommandSource::Skill,
+        ),
+    ]
+}
+
+/// Resolve a command or skill by name
+async fn resolve_command_or_skill(name: &str) -> Option<Resolution> {
+    let search_paths = get_search_paths(name);
+
+    for (path, source) in search_paths {
+        if let Ok(content) = fs::read_to_string(&path).await {
+            return Some(Resolution {
+                content,
+                source,
+                path: path.to_string_lossy().to_string(),
+            });
+        }
+    }
+
+    None
+}
+
+/// Extract prompt from YAML content
+fn extract_yaml_prompt(content: &str) -> String {
+    // Try to parse as YAML and extract prompt/instructions field
+    if let Ok(yaml) = serde_yaml::from_str::<serde_json::Value>(content) {
+        // Check for common prompt fields in order of preference
+        if let Some(prompt) = yaml.get("prompt").and_then(|v| v.as_str()) {
+            return prompt.to_string();
+        }
+        if let Some(instructions) = yaml.get("instructions").and_then(|v| v.as_str()) {
+            return instructions.to_string();
+        }
+        if let Some(description) = yaml.get("description").and_then(|v| v.as_str()) {
+            return description.to_string();
+        }
+    }
+    // Fallback: return the content as-is
+    content.to_string()
 }
 
 /// The SlashCommand tool
@@ -43,7 +143,7 @@ impl crate::Tool for SlashCommandTool {
     fn metadata(&self) -> ToolMetadata {
         ToolMetadata {
             name: "SlashCommand",
-            description: "Executes custom slash commands that expand to prompts",
+            description: "Executes custom slash commands and skills that expand to prompts. Supports both /command and /skill syntax.",
         }
     }
 
@@ -75,26 +175,60 @@ impl crate::Tool for SlashCommandTool {
             }
 
             yield ToolEvent::Progress {
-                step: format!("Loading command: {}", command_name),
+                step: format!("Loading command or skill: {}", command_name),
                 percentage: Some(40.0),
             };
 
-            // Look for command file in .claude/commands/
-            let command_path = PathBuf::from(format!(".claude/commands/{}.md", command_name));
+            // Resolve command/skill using unified resolution
+            let resolution = resolve_command_or_skill(&command_name).await;
 
-            let prompt_content = match fs::read_to_string(&command_path).await {
-                Ok(c) => c,
-                Err(_) => {
-                    // Command not found, return error
+            let (prompt_content, source, found_path) = match resolution {
+                Some(r) => (r.content, r.source, r.path),
+                None => {
+                    // Neither command nor skill found
+                    let search_paths = get_search_paths(&command_name);
                     yield ToolEvent::Error {
-                        message: format!("Command not found: {}", command_name),
+                        message: format!(
+                            "Command or skill not found: {}\nSearched in:\n{}",
+                            command_name,
+                            search_paths.iter()
+                                .map(|(p, _)| format!("  - {}", p.display()))
+                                .collect::<Vec<_>>()
+                                .join("\n")
+                        ),
                     };
                     return;
                 }
             };
 
-            // Parse markdown frontmatter if present
-            let expanded_prompt = if let Some(stripped) = prompt_content.strip_prefix("---") {
+            if debug {
+                tracing::debug!(
+                    command_name = %command_name,
+                    source = ?source,
+                    path = %found_path,
+                    "Resolved command/skill"
+                );
+            }
+
+            // Handle YAML files differently
+            let is_yaml = found_path.ends_with(".yaml") || found_path.ends_with(".yml");
+
+            // Parse markdown frontmatter if present (or handle YAML)
+            let expanded_prompt = if is_yaml {
+                // For YAML files, extract the prompt field
+                let base_prompt = extract_yaml_prompt(&prompt_content);
+                if let Some(args_str) = &args {
+                    let mut result = base_prompt;
+                    result = result.replace("{{args}}", args_str);
+                    let arg_parts: Vec<&str> = args_str.split_whitespace().collect();
+                    for (i, arg) in arg_parts.iter().enumerate() {
+                        result = result.replace(&format!("{{{}}}", i), arg);
+                    }
+                    result
+                } else {
+                    base_prompt
+                }
+            } else if let Some(stripped) = prompt_content.strip_prefix("---") {
                 // Find the end of frontmatter
                 if let Some(end_idx) = stripped.find("---") {
                     let frontmatter = &stripped[..end_idx];
@@ -153,6 +287,8 @@ impl crate::Tool for SlashCommandTool {
                 command: params.command.clone(),
                 expanded_prompt,
                 command_name,
+                source: Some(source),
+                path: Some(found_path),
             });
         }))
     }
@@ -171,7 +307,21 @@ mod tests {
     use super::*;
     use crate::Tool;
     use futures::StreamExt;
-    use std::path::PathBuf;
+
+    // Helper to extract result from events
+    fn get_result(events: &[ToolEvent<SlashCommandOutput>]) -> Option<&SlashCommandOutput> {
+        events.iter().find_map(|e| match e {
+            ToolEvent::Result(output) => Some(output),
+            _ => None,
+        })
+    }
+
+    // Helper to check for error event
+    fn has_error(events: &[ToolEvent<SlashCommandOutput>]) -> bool {
+        events.iter().any(|e| matches!(e, ToolEvent::Error { .. }))
+    }
+
+    // ===== Original Tests (Commands) =====
 
     #[tokio::test]
     async fn test_slash_command_parsing() {
@@ -192,17 +342,11 @@ mod tests {
         let stream = tool.execute(params, &ctx).await.unwrap();
         let events: Vec<_> = stream.collect().await;
 
-        let result = events
-            .iter()
-            .find_map(|e| match e {
-                ToolEvent::Result(output) => Some(output),
-                _ => None,
-            })
-            .unwrap();
-
+        let result = get_result(&events).unwrap();
         assert_eq!(result.command_name, "review-pr");
         assert!(!result.expanded_prompt.is_empty());
         assert!(result.expanded_prompt.contains("123") || result.expanded_prompt.contains("PR"));
+        assert_eq!(result.source, Some(CommandSource::Command));
 
         // Clean up
         let _ = fs::remove_file(&cmd_path).await;
@@ -219,9 +363,7 @@ mod tests {
         let stream = tool.execute(params, &ctx).await.unwrap();
         let events: Vec<_> = stream.collect().await;
 
-        // Should get an error event
-        let has_error = events.iter().any(|e| matches!(e, ToolEvent::Error { .. }));
-        assert!(has_error);
+        assert!(has_error(&events));
     }
 
     #[tokio::test]
@@ -243,14 +385,7 @@ mod tests {
         let stream = tool.execute(params, &ctx).await.unwrap();
         let events: Vec<_> = stream.collect().await;
 
-        let result = events
-            .iter()
-            .find_map(|e| match e {
-                ToolEvent::Result(output) => Some(output),
-                _ => None,
-            })
-            .unwrap();
-
+        let result = get_result(&events).unwrap();
         assert!(result.expanded_prompt.contains("foo"));
         assert!(result.expanded_prompt.contains("bar"));
         assert!(result.expanded_prompt.contains("baz"));
@@ -277,14 +412,7 @@ mod tests {
         let stream = tool.execute(params, &ctx).await.unwrap();
         let events: Vec<_> = stream.collect().await;
 
-        let result = events
-            .iter()
-            .find_map(|e| match e {
-                ToolEvent::Result(output) => Some(output),
-                _ => None,
-            })
-            .unwrap();
-
+        let result = get_result(&events).unwrap();
         assert!(result.expanded_prompt.contains("one two three"));
 
         let _ = fs::remove_file(&cmd_path).await;
@@ -308,14 +436,7 @@ mod tests {
         let stream = tool.execute(params, &ctx).await.unwrap();
         let events: Vec<_> = stream.collect().await;
 
-        let result = events
-            .iter()
-            .find_map(|e| match e {
-                ToolEvent::Result(output) => Some(output),
-                _ => None,
-            })
-            .unwrap();
-
+        let result = get_result(&events).unwrap();
         assert!(result.expanded_prompt.contains("Simple command"));
 
         let _ = fs::remove_file(&cmd_path).await;
@@ -340,17 +461,8 @@ mod tests {
         let stream = tool.execute(params, &ctx).await.unwrap();
         let events: Vec<_> = stream.collect().await;
 
-        let result = events
-            .iter()
-            .find_map(|e| match e {
-                ToolEvent::Result(output) => Some(output),
-                _ => None,
-            })
-            .unwrap();
-
-        assert!(result
-            .expanded_prompt
-            .contains("This command takes no arguments"));
+        let result = get_result(&events).unwrap();
+        assert!(result.expanded_prompt.contains("This command takes no arguments"));
 
         let _ = fs::remove_file(&cmd_path).await;
     }
@@ -367,8 +479,7 @@ mod tests {
         let events: Vec<_> = stream.collect().await;
 
         // Should get an error since command name is empty
-        let has_error = events.iter().any(|e| matches!(e, ToolEvent::Error { .. }));
-        assert!(has_error);
+        assert!(has_error(&events));
     }
 
     #[tokio::test]
@@ -389,14 +500,7 @@ mod tests {
         let stream = tool.execute(params, &ctx).await.unwrap();
         let events: Vec<_> = stream.collect().await;
 
-        let result = events
-            .iter()
-            .find_map(|e| match e {
-                ToolEvent::Result(output) => Some(output),
-                _ => None,
-            })
-            .unwrap();
-
+        let result = get_result(&events).unwrap();
         assert!(result.expanded_prompt.contains("arg with multiple words"));
 
         let _ = fs::remove_file(&cmd_path).await;
@@ -433,17 +537,237 @@ mod tests {
         let stream = tool.execute(params, &ctx).await.unwrap();
         let events: Vec<_> = stream.collect().await;
 
-        let result = events
-            .iter()
-            .find_map(|e| match e {
-                ToolEvent::Result(output) => Some(output),
-                _ => None,
-            })
-            .unwrap();
-
+        let result = get_result(&events).unwrap();
         // Should still return content even with malformed frontmatter
         assert!(!result.expanded_prompt.is_empty());
 
         let _ = fs::remove_file(&cmd_path).await;
+    }
+
+    // ===== New Tests (Skills Resolution) =====
+
+    #[tokio::test]
+    async fn test_skill_direct_file_resolution() {
+        // Create a skill as direct .md file
+        let skill_dir = PathBuf::from(".claude/skills");
+        let _ = fs::create_dir_all(&skill_dir).await;
+
+        let skill_path = skill_dir.join("test-skill-direct.md");
+        let test_content = "---\ndescription: A test skill\n---\n\nThis is a test skill prompt.\n";
+        let _ = fs::write(&skill_path, test_content).await;
+
+        let tool = SlashCommandTool;
+        let params = SlashCommandParams {
+            command: "/test-skill-direct".to_string(),
+        };
+        let ctx = ToolContext::default();
+
+        let stream = tool.execute(params, &ctx).await.unwrap();
+        let events: Vec<_> = stream.collect().await;
+
+        let result = get_result(&events).unwrap();
+        assert_eq!(result.command_name, "test-skill-direct");
+        assert!(result.expanded_prompt.contains("test skill prompt"));
+        assert_eq!(result.source, Some(CommandSource::Skill));
+        assert!(result.path.as_ref().unwrap().contains(".claude/skills/"));
+
+        let _ = fs::remove_file(&skill_path).await;
+    }
+
+    #[tokio::test]
+    async fn test_skill_subdirectory_uppercase_resolution() {
+        // Create a skill in subdirectory with SKILL.md (uppercase)
+        let skill_dir = PathBuf::from(".claude/skills/test-skill-upper");
+        let _ = fs::create_dir_all(&skill_dir).await;
+
+        let skill_path = skill_dir.join("SKILL.md");
+        let test_content = "---\ndescription: Uppercase skill\n---\n\nUppercase SKILL.md content.\n";
+        let _ = fs::write(&skill_path, test_content).await;
+
+        let tool = SlashCommandTool;
+        let params = SlashCommandParams {
+            command: "/test-skill-upper".to_string(),
+        };
+        let ctx = ToolContext::default();
+
+        let stream = tool.execute(params, &ctx).await.unwrap();
+        let events: Vec<_> = stream.collect().await;
+
+        let result = get_result(&events).unwrap();
+        assert_eq!(result.command_name, "test-skill-upper");
+        assert!(result.expanded_prompt.contains("Uppercase SKILL.md"));
+        assert_eq!(result.source, Some(CommandSource::Skill));
+
+        let _ = fs::remove_dir_all(&skill_dir).await;
+    }
+
+    #[tokio::test]
+    async fn test_skill_yaml_resolution() {
+        // Create a YAML skill file
+        let skill_dir = PathBuf::from(".claude/skills");
+        let _ = fs::create_dir_all(&skill_dir).await;
+
+        let skill_path = skill_dir.join("test-yaml-skill.yaml");
+        let test_content = "description: A YAML skill\nprompt: This is a YAML skill prompt with arg {0}.\n";
+        let _ = fs::write(&skill_path, test_content).await;
+
+        let tool = SlashCommandTool;
+        let params = SlashCommandParams {
+            command: "/test-yaml-skill myarg".to_string(),
+        };
+        let ctx = ToolContext::default();
+
+        let stream = tool.execute(params, &ctx).await.unwrap();
+        let events: Vec<_> = stream.collect().await;
+
+        let result = get_result(&events).unwrap();
+        assert_eq!(result.command_name, "test-yaml-skill");
+        assert!(result.expanded_prompt.contains("YAML skill prompt"));
+        assert!(result.expanded_prompt.contains("myarg"));
+        assert_eq!(result.source, Some(CommandSource::Skill));
+
+        let _ = fs::remove_file(&skill_path).await;
+    }
+
+    #[tokio::test]
+    async fn test_command_takes_priority_over_skill() {
+        // Create both a command and a skill with the same name
+        let cmd_dir = PathBuf::from(".claude/commands");
+        let skill_dir = PathBuf::from(".claude/skills");
+        let _ = fs::create_dir_all(&cmd_dir).await;
+        let _ = fs::create_dir_all(&skill_dir).await;
+
+        let cmd_path = cmd_dir.join("priority-test.md");
+        let skill_path = skill_dir.join("priority-test.md");
+
+        let _ = fs::write(&cmd_path, "---\ndescription: Command version\n---\n\nThis is the COMMAND.\n").await;
+        let _ = fs::write(&skill_path, "---\ndescription: Skill version\n---\n\nThis is the SKILL.\n").await;
+
+        let tool = SlashCommandTool;
+        let params = SlashCommandParams {
+            command: "/priority-test".to_string(),
+        };
+        let ctx = ToolContext::default();
+
+        let stream = tool.execute(params, &ctx).await.unwrap();
+        let events: Vec<_> = stream.collect().await;
+
+        let result = get_result(&events).unwrap();
+        assert!(result.expanded_prompt.contains("COMMAND"));
+        assert!(!result.expanded_prompt.contains("SKILL"));
+        assert_eq!(result.source, Some(CommandSource::Command));
+
+        let _ = fs::remove_file(&cmd_path).await;
+        let _ = fs::remove_file(&skill_path).await;
+    }
+
+    #[tokio::test]
+    async fn test_skill_with_arguments() {
+        let skill_dir = PathBuf::from(".claude/skills");
+        let _ = fs::create_dir_all(&skill_dir).await;
+
+        let skill_path = skill_dir.join("skill-with-args.md");
+        let test_content = "---\ndescription: Skill with args\n---\n\nProcess: {0} and {1}. All: {{args}}\n";
+        let _ = fs::write(&skill_path, test_content).await;
+
+        let tool = SlashCommandTool;
+        let params = SlashCommandParams {
+            command: "/skill-with-args first second".to_string(),
+        };
+        let ctx = ToolContext::default();
+
+        let stream = tool.execute(params, &ctx).await.unwrap();
+        let events: Vec<_> = stream.collect().await;
+
+        let result = get_result(&events).unwrap();
+        assert!(result.expanded_prompt.contains("first"));
+        assert!(result.expanded_prompt.contains("second"));
+        assert!(result.expanded_prompt.contains("first second"));
+        assert_eq!(result.source, Some(CommandSource::Skill));
+
+        let _ = fs::remove_file(&skill_path).await;
+    }
+
+    #[tokio::test]
+    async fn test_error_message_shows_search_paths() {
+        let tool = SlashCommandTool;
+        let params = SlashCommandParams {
+            command: "/totally-nonexistent-command".to_string(),
+        };
+        let ctx = ToolContext::default();
+
+        let stream = tool.execute(params, &ctx).await.unwrap();
+        let events: Vec<_> = stream.collect().await;
+
+        // Find the error event and check its message
+        let error_msg = events.iter().find_map(|e| match e {
+            ToolEvent::Error { message } => Some(message.clone()),
+            _ => None,
+        }).expect("Should have error event");
+
+        // Verify error message shows search paths
+        assert!(error_msg.contains(".claude/commands/"));
+        assert!(error_msg.contains(".claude/skills/"));
+        assert!(error_msg.contains("SKILL.md"));
+    }
+
+    // ===== Unit Tests for Helper Functions =====
+
+    #[test]
+    fn test_get_search_paths() {
+        let paths = get_search_paths("my-skill");
+        assert_eq!(paths.len(), 5);
+
+        // Verify order - commands first
+        assert!(paths[0].0.to_string_lossy().contains("commands"));
+        assert_eq!(paths[0].1, CommandSource::Command);
+
+        // Then skills
+        assert!(paths[1].0.to_string_lossy().contains("skills"));
+        assert_eq!(paths[1].1, CommandSource::Skill);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_command_or_skill_command() {
+        let cmd_dir = PathBuf::from(".claude/commands");
+        let _ = fs::create_dir_all(&cmd_dir).await;
+
+        let cmd_path = cmd_dir.join("resolve-test-cmd.md");
+        let _ = fs::write(&cmd_path, "test content").await;
+
+        let result = resolve_command_or_skill("resolve-test-cmd").await;
+        assert!(result.is_some());
+        let resolution = result.unwrap();
+        assert_eq!(resolution.source, CommandSource::Command);
+        assert!(resolution.path.contains("commands"));
+
+        let _ = fs::remove_file(&cmd_path).await;
+    }
+
+    #[tokio::test]
+    async fn test_resolve_command_or_skill_not_found() {
+        let result = resolve_command_or_skill("definitely-not-exists-xyz").await;
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_extract_yaml_prompt() {
+        let yaml = "description: test\nprompt: The actual prompt\n";
+        let prompt = extract_yaml_prompt(yaml);
+        assert_eq!(prompt, "The actual prompt");
+    }
+
+    #[test]
+    fn test_extract_yaml_prompt_instructions_field() {
+        let yaml = "description: test\ninstructions: Use these instructions\n";
+        let prompt = extract_yaml_prompt(yaml);
+        assert_eq!(prompt, "Use these instructions");
+    }
+
+    #[test]
+    fn test_extract_yaml_prompt_fallback() {
+        let yaml = "description: Only description here\n";
+        let prompt = extract_yaml_prompt(yaml);
+        assert_eq!(prompt, "Only description here");
     }
 }


### PR DESCRIPTION
## Summary

- Implements Issue #207: Skill/SlashCommand unification
- Like Claude Code, skills can now be invoked via `/skill-name` syntax
- SlashCommandTool searches both commands and skills directories with defined priority
- Commands take precedence over skills for backward compatibility

## Resolution Order

1. `.claude/commands/{name}.md` - Traditional commands (highest priority)
2. `.claude/skills/{name}.md` - Direct skill file
3. `.claude/skills/{name}/SKILL.md` - Skill in subdirectory (uppercase)
4. `.claude/skills/{name}/skill.md` - Skill in subdirectory (lowercase)
5. `.claude/skills/{name}.yaml` - YAML skill file

## New Features

- Added `CommandSource` enum to identify where command/skill was found
- Added `source` and `path` fields to `SlashCommandOutput`
- Improved error messages showing all searched paths
- Support for YAML skill files with `prompt`/`instructions` fields
- Full argument substitution support for skills (`{{args}}` and `{0}` placeholders)

## Test plan

- [x] All 23 tests pass (12 original + 11 new for skill resolution)
- [x] Tests cover: command resolution, skill resolution, priority ordering, argument substitution
- [x] Tests cover: YAML skill files, subdirectory skills, error messages
- [x] Clippy passes with no warnings
- [x] Cargo test passes

Closes #207

Generated with [Claude Code](https://claude.com/claude-code)