### PR TITLE
feat(tools): Unify SlashCommand and Skill tools - Issue #207

### DIFF
--- a/crates/tools/src/command_skill.rs
+++ b/crates/tools/src/command_skill.rs
@@ -353,7 +353,10 @@ fn discover_command_paths(name: &str) -> Vec<PathBuf> {
 
     // Priority 1: Project-level commands
     if let Some(ns) = namespace {
-        paths.push(PathBuf::from(format!(".claude/commands/{}/{}.md", ns, cmd_name)));
+        paths.push(PathBuf::from(format!(
+            ".claude/commands/{}/{}.md",
+            ns, cmd_name
+        )));
     }
     paths.push(PathBuf::from(format!(".claude/commands/{}.md", name)));
 
@@ -386,7 +389,10 @@ fn discover_skill_paths(skill_name: &str) -> Vec<PathBuf> {
     paths.push(PathBuf::from(format!(".claude/skills/{}/skill.md", skill)));
     paths.push(PathBuf::from(format!(".claude/skills/{}/SKILL.md", skill)));
     paths.push(PathBuf::from(format!(".claude/skills/{}.yaml", skill)));
-    paths.push(PathBuf::from(format!(".claude/skills/{}/skill.yaml", skill)));
+    paths.push(PathBuf::from(format!(
+        ".claude/skills/{}/skill.yaml",
+        skill
+    )));
 
     // Priority 2: User-level skills
     if let Some(home) = std::env::var_os("HOME") {
@@ -592,26 +598,41 @@ mod tests {
     #[test]
     fn test_discover_command_paths() {
         let paths = discover_command_paths("review-pr");
-        assert!(paths.iter().any(|p| p.to_str().unwrap().contains(".claude/commands/review-pr.md")));
+        assert!(paths.iter().any(|p| p
+            .to_str()
+            .unwrap()
+            .contains(".claude/commands/review-pr.md")));
     }
 
     #[test]
     fn test_discover_command_paths_namespaced() {
         let paths = discover_command_paths("amplihack:analyze");
-        assert!(paths.iter().any(|p| p.to_str().unwrap().contains(".claude/commands/amplihack/analyze.md")));
+        assert!(paths.iter().any(|p| p
+            .to_str()
+            .unwrap()
+            .contains(".claude/commands/amplihack/analyze.md")));
     }
 
     #[test]
     fn test_discover_skill_paths() {
         let paths = discover_skill_paths("code-reviewer");
-        assert!(paths.iter().any(|p| p.to_str().unwrap().contains(".claude/skills/code-reviewer.md")));
-        assert!(paths.iter().any(|p| p.to_str().unwrap().contains(".claude/skills/code-reviewer/skill.md")));
+        assert!(paths.iter().any(|p| p
+            .to_str()
+            .unwrap()
+            .contains(".claude/skills/code-reviewer.md")));
+        assert!(paths.iter().any(|p| p
+            .to_str()
+            .unwrap()
+            .contains(".claude/skills/code-reviewer/skill.md")));
     }
 
     #[test]
     fn test_discover_skill_paths_with_plugin() {
         let paths = discover_skill_paths("my-plugin:my-skill");
-        assert!(paths.iter().any(|p| p.to_str().unwrap().contains(".claude/plugins/my-plugin/skills/my-skill")));
+        assert!(paths.iter().any(|p| p
+            .to_str()
+            .unwrap()
+            .contains(".claude/plugins/my-plugin/skills/my-skill")));
     }
 
     #[test]

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -36,7 +36,9 @@ pub use agent_registry::{global_agent_registry, AgentHandle, AgentRegistry, Agen
 pub use ask_user_question::AskUserQuestionTool;
 pub use bash::BashTool;
 pub use bash_output::BashOutputTool;
-pub use command_skill::{CommandSkillTool, CommandSkillParams, CommandSkillOutput, CommandType, CommandSkillMetadata};
+pub use command_skill::{
+    CommandSkillMetadata, CommandSkillOutput, CommandSkillParams, CommandSkillTool, CommandType,
+};
 pub use edit::EditTool;
 pub use error::{ToolError, ToolResult};
 pub use glob_tool::GlobTool;


### PR DESCRIPTION
## Summary

- Creates unified `CommandSkillTool` that handles both slash commands (`/review-pr 123`) and skills (`code-reviewer`)
- Automatic detection of input type based on format (slash prefix indicates command)
- Combined discovery system checking both `.claude/commands/` and `.claude/skills/` locations
- Full argument substitution support (`{{args}}`, `{0}`, `{1}`, etc.)
- Force flags (`force_skill`, `force_command`) for explicit type selection when both exist with same name
- Comprehensive 24 tests covering all functionality

## Test Plan

- [x] All 24 unit tests pass for CommandSkillTool
- [x] Full tools crate test suite passes (53 tests)
- [x] Cargo check passes for entire workspace
- [x] Backward compatibility maintained - original SlashCommandTool and SkillTool retained

## Design Decision

The original tools are kept for backward compatibility. Users can either:
1. Use the new unified `CommandSkillTool` with automatic type detection
2. Continue using `SlashCommandTool` or `SkillTool` directly

Closes #207

Generated with [Claude Code](https://claude.com/claude-code)