### PR TITLE
feat(hooks): Expose CLAUDE_TOOL_USE_ID env var to command hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,7 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "url",
 ]

--- a/crates/cli/src/hooks/executor.rs
+++ b/crates/cli/src/hooks/executor.rs
@@ -143,6 +143,10 @@ impl HookExecutor {
             cmd.env("CLAUDE_TOOL_NAME", tool_name);
         }
 
+        if let Some(tool_use_id) = &context.tool_use_id {
+            cmd.env("CLAUDE_TOOL_USE_ID", tool_use_id);
+        }
+
         if let Some(env_file) = env_file {
             cmd.env("CLAUDE_ENV_FILE", env_file);
         }
@@ -430,5 +434,68 @@ mod tests {
         }
 
         assert!(result[0].is_success());
+    }
+
+    #[tokio::test]
+    async fn test_command_hook_receives_tool_use_id_env_var() {
+        // This test verifies that CLAUDE_TOOL_USE_ID is set for tool-related hooks
+        let hook = Hook::command("echo $CLAUDE_TOOL_USE_ID".to_string(), Some(5000));
+        let context = HookContext::for_tool(
+            "test-session".to_string(),
+            "/tmp/transcript".to_string(),
+            std::env::current_dir()
+                .unwrap()
+                .to_string_lossy()
+                .to_string(),
+            "ask".to_string(),
+            HookEvent::PreToolUse,
+            "Write".to_string(),
+            Some("toolu_test_123".to_string()),
+        );
+
+        let executor = HookExecutor::new();
+        let result = executor.execute_hooks(&[hook], &context).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(result[0].is_success());
+        // Verify the tool_use_id was passed through environment variable
+        assert!(
+            result[0].stdout.trim().contains("toolu_test_123"),
+            "Expected CLAUDE_TOOL_USE_ID to be set. Got stdout: {}",
+            result[0].stdout
+        );
+    }
+
+    #[tokio::test]
+    async fn test_command_hook_tool_use_id_not_set_when_none() {
+        // Verify that CLAUDE_TOOL_USE_ID is NOT set when context has None
+        let hook = Hook::command(
+            "echo \"ID:$CLAUDE_TOOL_USE_ID:END\"".to_string(),
+            Some(5000),
+        );
+        let context = HookContext::for_tool(
+            "test-session".to_string(),
+            "/tmp/transcript".to_string(),
+            std::env::current_dir()
+                .unwrap()
+                .to_string_lossy()
+                .to_string(),
+            "ask".to_string(),
+            HookEvent::PreToolUse,
+            "Write".to_string(),
+            None, // No tool_use_id
+        );
+
+        let executor = HookExecutor::new();
+        let result = executor.execute_hooks(&[hook], &context).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(result[0].is_success());
+        // When tool_use_id is None, the env var should not be set (empty)
+        assert!(
+            result[0].stdout.trim() == "ID::END",
+            "Expected empty CLAUDE_TOOL_USE_ID when None. Got stdout: {}",
+            result[0].stdout
+        );
     }
 }

--- a/docs/HOOK_LIFECYCLE_INTEGRATION.md
+++ b/docs/HOOK_LIFECYCLE_INTEGRATION.md
@@ -1066,6 +1066,7 @@ All command hooks receive:
 - `CLAUDE_PERMISSION_MODE` - Permission mode (auto/ask/always)
 - `CLAUDE_HOOK_EVENT` - Event name (e.g., "PreToolUse")
 - `CLAUDE_TOOL_NAME` - Tool name (for tool-related events)
+- `CLAUDE_TOOL_USE_ID` - Unique identifier for this tool invocation (for PreToolUse/PostToolUse events), allows correlating pre/post hooks for the same tool call
 - `CLAUDE_PROJECT_DIR` - Project root directory
 
 #### Hook Context as JSON


### PR DESCRIPTION
## Summary

- Adds `CLAUDE_TOOL_USE_ID` environment variable to command hooks for PreToolUse and PostToolUse events
- Enables bash/shell hooks to access the unique tool invocation identifier
- Allows correlation of pre and post tool use events for the same tool call

## Changes

1. **crates/cli/src/hooks/executor.rs**:
   - Added code to set `CLAUDE_TOOL_USE_ID` env var when `tool_use_id` is present in context
   - Added two new tests verifying the env var behavior

2. **docs/HOOK_LIFECYCLE_INTEGRATION.md**:
   - Documented the new `CLAUDE_TOOL_USE_ID` environment variable

## Test Plan

- [x] `cargo fmt --all` - Passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - Passes
- [x] `cargo test --package rustyclawd-cli hooks` - 50 tests pass
- [x] `cargo test test_tool_use_id` - 12 tests pass
- [x] Hook lifecycle integration tests - 30 tests pass
- [x] New tests added:
  - `test_command_hook_receives_tool_use_id_env_var` - Verifies env var is set when tool_use_id present
  - `test_command_hook_tool_use_id_not_set_when_none` - Verifies env var is empty when tool_use_id is None

## Step 13: Local Testing Results

**Scenario 1: Basic env var exposure test**
- Created hook config that echoes `$CLAUDE_TOOL_USE_ID`
- Verified tool_use_id value (e.g., `toolu_test_123`) appears in hook stdout
- Result: PASS

**Scenario 2: Correlation test**
- Verified pre and post tool use hooks receive same tool_use_id
- Verified multiple tool invocations get different IDs
- Result: PASS (verified via `test_pre_and_post_tool_use_correlation` and `test_multiple_tool_invocations_different_ids` tests)

Closes #196

---
Generated with Claude Code