### PR TITLE
feat(mcp): Add structuredContent field to MCP tool responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,7 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "url",
 ]

--- a/crates/cli/src/interactive.rs
+++ b/crates/cli/src/interactive.rs
@@ -521,6 +521,7 @@ impl InteractiveSession {
                                     stderr,
                                     is_error: is_error.unwrap_or(false),
                                     raw_content: content_text,
+                                    structured_content: None,
                                 }
                             } else {
                                 // Non-ToolResult content block (shouldn't happen)
@@ -530,6 +531,7 @@ impl InteractiveSession {
                                     stderr: "Unexpected result format".to_string(),
                                     is_error: true,
                                     raw_content: "Unexpected result format".to_string(),
+                                    structured_content: None,
                                 }
                             };
 
@@ -557,6 +559,7 @@ impl InteractiveSession {
                                     stderr: error.clone(),
                                     is_error: true,
                                     raw_content: format!("Tool execution error: {}", error),
+                                    structured_content: None,
                                 };
 
                                 // Finalize tool message with error

--- a/crates/cli/src/mcp_commands.rs
+++ b/crates/cli/src/mcp_commands.rs
@@ -10,7 +10,7 @@
 //!
 //! Used by both CLI (claude mcp ...) and TUI (/mcp-... commands)
 
-use crate::plugins::mcp_proxy::{McpProxy, McpServerInstance};
+use crate::plugins::mcp_proxy::{McpCallToolResult, McpProxy, McpServerInstance};
 use crate::tool_definitions;
 use serde::{Deserialize, Serialize};
 use std::io::{self, BufRead, Write};
@@ -210,16 +210,22 @@ async fn handle_tools_call(request: &JsonRpcRequest) -> JsonRpcResponse {
     // Future enhancement: Integrate with crate::tool_executor::execute_tool
     // to provide full tool execution capability.
 
+    // Build MCP-compliant CallToolResult with optional structuredContent
+    let tool_result = McpCallToolResult {
+        content: vec![serde_json::json!({
+            "type": "text",
+            "text": format!("Tool '{}' invoked with parameters. Full execution requires session context.", tool_name)
+        })],
+        // structuredContent can be provided when tool has outputSchema
+        // and returns typed data. For now, set to None.
+        structured_content: None,
+        is_error: Some(false),
+    };
+
     JsonRpcResponse {
         jsonrpc: "2.0".to_string(),
         id: request.id.clone(),
-        result: Some(serde_json::json!({
-            "content": [{
-                "type": "text",
-                "text": format!("Tool '{}' invoked with parameters. Full execution requires session context.", tool_name)
-            }],
-            "isError": false
-        })),
+        result: Some(serde_json::to_value(tool_result).unwrap_or_default()),
         error: None,
     }
 }

--- a/crates/cli/src/plugins/mcp_proxy.rs
+++ b/crates/cli/src/plugins/mcp_proxy.rs
@@ -65,6 +65,25 @@ pub struct McpToolDefinition {
     pub input_schema: serde_json::Value,
 }
 
+/// MCP CallToolResult per MCP spec (2025-11-25)
+///
+/// Represents the result of executing a tool via tools/call.
+/// Includes both human-readable content and optional structured JSON data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpCallToolResult {
+    /// Array of content blocks (text, images, etc.) for human-readable output
+    pub content: Vec<serde_json::Value>,
+    /// Optional structured JSON result matching the tool's declared outputSchema.
+    /// Use this when returning typed data that callers can parse programmatically.
+    #[serde(rename = "structuredContent")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub structured_content: Option<serde_json::Value>,
+    /// Whether this is an error response
+    #[serde(rename = "isError")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
+}
+
 /// MCP resource definition from server
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Resource {

--- a/crates/cli/src/plugins/mod.rs
+++ b/crates/cli/src/plugins/mod.rs
@@ -52,7 +52,7 @@ pub use executor::PluginExecutor;
 pub use hooks_integration::{register_plugin_hooks, PluginHooksIntegrator};
 pub use loader::PluginLoader;
 pub use manager::{PluginManager, PluginSystemSummary};
-pub use mcp_proxy::McpProxy;
+pub use mcp_proxy::{McpCallToolResult, McpProxy};
 
 /// Plugin system version
 pub const PLUGIN_VERSION: &str = "1.0.0";

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -54,6 +54,9 @@ pub struct ToolResult {
     pub is_error: bool,
     /// Raw content (for expanded view - shows full API response)
     pub raw_content: String,
+    /// Optional structured JSON content (MCP spec structuredContent field)
+    /// Contains typed data conforming to the tool's outputSchema when available
+    pub structured_content: Option<serde_json::Value>,
 }
 
 /// Completion item for slash command autocomplete

--- a/crates/cli/tests/mcp_structured_content_tests.rs
+++ b/crates/cli/tests/mcp_structured_content_tests.rs
@@ -1,0 +1,197 @@
+//! MCP structuredContent Field Tests
+//!
+//! Tests for the MCP `structuredContent` field in tool responses.
+//! Per MCP spec (2025-11-25), `CallToolResult` includes:
+//! - content: Vec<ContentBlock> - human-readable results
+//! - structuredContent: Option<serde_json::Value> - typed JSON matching outputSchema
+//! - isError: Option<bool> - error indicator
+
+use rustyclawd::plugins::mcp_proxy::McpCallToolResult;
+use serde_json::json;
+
+#[test]
+fn test_mcp_call_tool_result_serialization_with_structured_content() {
+    let result = McpCallToolResult {
+        content: vec![json!({
+            "type": "text",
+            "text": "Found 3 files"
+        })],
+        structured_content: Some(json!({
+            "files": [
+                {"path": "/src/main.rs", "size": 1024},
+                {"path": "/src/lib.rs", "size": 512}
+            ],
+            "total_count": 2
+        })),
+        is_error: None,
+    };
+
+    // Test serialization
+    let json_str = serde_json::to_string(&result).unwrap();
+
+    // Verify structuredContent is present and in camelCase
+    assert!(
+        json_str.contains("structuredContent"),
+        "Should serialize as camelCase structuredContent"
+    );
+    assert!(json_str.contains("files"));
+    assert!(json_str.contains("/src/main.rs"));
+}
+
+#[test]
+fn test_mcp_call_tool_result_without_structured_content() {
+    let result = McpCallToolResult {
+        content: vec![json!({
+            "type": "text",
+            "text": "Simple result"
+        })],
+        structured_content: None,
+        is_error: None,
+    };
+
+    // Test serialization
+    let json_str = serde_json::to_string(&result).unwrap();
+
+    // Verify structuredContent is omitted when None
+    assert!(
+        !json_str.contains("structuredContent"),
+        "Should omit structuredContent when None"
+    );
+    assert!(json_str.contains("content"));
+    assert!(json_str.contains("Simple result"));
+}
+
+#[test]
+fn test_mcp_call_tool_result_deserialization_with_structured_content() {
+    // Simulate MCP server response with structuredContent
+    let json_str = r#"{
+        "content": [{"type": "text", "text": "Analysis complete"}],
+        "structuredContent": {
+            "issues": [
+                {"severity": "warning", "message": "Unused variable"},
+                {"severity": "error", "message": "Syntax error"}
+            ],
+            "summary": {"total": 2, "errors": 1, "warnings": 1}
+        },
+        "isError": false
+    }"#;
+
+    let result: McpCallToolResult = serde_json::from_str(json_str).unwrap();
+
+    assert_eq!(result.content.len(), 1);
+    assert!(result.structured_content.is_some());
+
+    let structured = result.structured_content.unwrap();
+    assert!(structured.get("issues").is_some());
+    assert!(structured.get("summary").is_some());
+
+    let summary = structured.get("summary").unwrap();
+    assert_eq!(summary.get("total").unwrap(), 2);
+}
+
+#[test]
+fn test_mcp_call_tool_result_deserialization_without_structured_content() {
+    // Simulate MCP server response without structuredContent (backward compat)
+    let json_str = r#"{
+        "content": [{"type": "text", "text": "Done"}],
+        "isError": false
+    }"#;
+
+    let result: McpCallToolResult = serde_json::from_str(json_str).unwrap();
+
+    assert_eq!(result.content.len(), 1);
+    assert!(result.structured_content.is_none());
+    assert_eq!(result.is_error, Some(false));
+}
+
+#[test]
+fn test_mcp_call_tool_result_with_complex_structured_content() {
+    // Test with nested objects and arrays
+    let result = McpCallToolResult {
+        content: vec![json!({"type": "text", "text": "Complex result"})],
+        structured_content: Some(json!({
+            "database": {
+                "tables": [
+                    {
+                        "name": "users",
+                        "columns": ["id", "name", "email"],
+                        "row_count": 1500
+                    },
+                    {
+                        "name": "orders",
+                        "columns": ["id", "user_id", "total"],
+                        "row_count": 5000
+                    }
+                ],
+                "version": "14.2"
+            },
+            "metrics": {
+                "query_time_ms": 42,
+                "cache_hit": true
+            }
+        })),
+        is_error: None,
+    };
+
+    // Round-trip test
+    let json_str = serde_json::to_string(&result).unwrap();
+    let deserialized: McpCallToolResult = serde_json::from_str(&json_str).unwrap();
+
+    assert!(deserialized.structured_content.is_some());
+    let structured = deserialized.structured_content.unwrap();
+
+    let tables = structured["database"]["tables"].as_array().unwrap();
+    assert_eq!(tables.len(), 2);
+    assert_eq!(tables[0]["name"], "users");
+    assert_eq!(structured["metrics"]["query_time_ms"], 42);
+}
+
+#[test]
+fn test_mcp_call_tool_result_error_with_structured_content() {
+    // Error responses can also have structuredContent
+    let result = McpCallToolResult {
+        content: vec![json!({
+            "type": "text",
+            "text": "Validation failed"
+        })],
+        structured_content: Some(json!({
+            "errors": [
+                {"field": "email", "code": "INVALID_FORMAT"},
+                {"field": "age", "code": "OUT_OF_RANGE"}
+            ],
+            "error_count": 2
+        })),
+        is_error: Some(true),
+    };
+
+    let json_str = serde_json::to_string(&result).unwrap();
+    let deserialized: McpCallToolResult = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(deserialized.is_error, Some(true));
+    assert!(deserialized.structured_content.is_some());
+
+    let structured = deserialized.structured_content.unwrap();
+    let errors = structured["errors"].as_array().unwrap();
+    assert_eq!(errors.len(), 2);
+}
+
+#[test]
+fn test_mcp_call_tool_result_camel_case_field_names() {
+    // Verify MCP spec compliance with camelCase field names
+    let json_str = r#"{
+        "content": [{"type": "text", "text": "test"}],
+        "structuredContent": {"key": "value"},
+        "isError": false
+    }"#;
+
+    let result: McpCallToolResult = serde_json::from_str(json_str).unwrap();
+    assert!(result.structured_content.is_some());
+    assert_eq!(result.is_error, Some(false));
+
+    // Serialization should produce camelCase
+    let serialized = serde_json::to_string(&result).unwrap();
+    assert!(serialized.contains("structuredContent"));
+    assert!(serialized.contains("isError"));
+    assert!(!serialized.contains("structured_content"));
+    assert!(!serialized.contains("is_error"));
+}

--- a/docs/STRUCTURED_CONTENT.md
+++ b/docs/STRUCTURED_CONTENT.md
@@ -106,9 +106,63 @@ For tool developers:
 2. **To use structured content**: Return `Vec<ContentBlock>` instead of `String`
 3. **Testing**: Both old and new formats are covered by tests in `crates/core/tests/tool_use_test.rs`
 
+## structuredContent Field
+
+In addition to the `content` array, tool results can include an optional `structuredContent` field containing typed JSON data that conforms to the tool's declared `outputSchema`.
+
+### MCP CallToolResult Schema
+
+Per the MCP specification (2025-11-25), the complete `CallToolResult` structure is:
+
+```rust
+pub struct McpCallToolResult {
+    /// Array of content blocks (text, images, etc.)
+    pub content: Vec<ContentBlock>,
+    /// Optional structured JSON result matching tool's outputSchema
+    pub structured_content: Option<serde_json::Value>,
+    /// Whether this is an error response
+    pub is_error: Option<bool>,
+}
+```
+
+### When to Use structuredContent
+
+Use `structuredContent` when:
+- The tool has a declared `outputSchema` in its definition
+- Callers need machine-parseable results beyond text
+- Returning structured data (objects, arrays) that match a specific schema
+
+### Example with structuredContent
+
+```rust
+// MCP tool result with both content and structuredContent
+McpCallToolResult {
+    content: vec![ContentBlock::Text {
+        text: "Found 3 files matching pattern".to_string(),
+    }],
+    structured_content: Some(serde_json::json!({
+        "files": [
+            {"path": "/src/main.rs", "size": 1024},
+            {"path": "/src/lib.rs", "size": 512},
+            {"path": "/tests/test.rs", "size": 256}
+        ],
+        "total_count": 3
+    })),
+    is_error: None,
+}
+```
+
+### Backward Compatibility
+
+The `structuredContent` field is optional:
+- Existing tools without output schemas continue to work unchanged
+- MCP servers that don't return `structuredContent` are handled gracefully
+- When present, `structuredContent` provides typed data alongside human-readable `content`
+
 ## MCP Spec Compliance
 
 This implementation follows the Model Context Protocol specification for tool results:
 - Supports array of content blocks per MCP spec
+- Supports optional `structuredContent` field for typed JSON responses
 - Maintains backward compatibility with existing implementations
 - Enables richer tool responses with multiple content types


### PR DESCRIPTION
## Summary

- Implements MCP spec (2025-11-25) `structuredContent` field for `CallToolResult`
- This optional field allows tools to return typed JSON data alongside human-readable content
- Enables machine-parseable results for tools with declared `outputSchema`

## Changes

- **McpCallToolResult struct**: New type in `mcp_proxy.rs` with `content`, `structured_content`, `is_error` fields
- **handle_tools_call**: Updated to use `McpCallToolResult` for MCP spec compliance  
- **TUI ToolResult**: Extended with optional `structured_content` field for future display
- **Documentation**: Updated `STRUCTURED_CONTENT.md` with new field documentation
- **Tests**: 7 comprehensive tests for serialization, deserialization, and edge cases

## MCP Spec Compliance

Per MCP spec (2025-11-25), `CallToolResult` includes:
- `content`: Array of content blocks (text, images, etc.)
- `structuredContent` (optional): Typed JSON matching tool's `outputSchema`
- `isError` (optional): Error indicator

## Test Plan

- [x] Unit tests for McpCallToolResult serialization/deserialization (7 tests)
- [x] Verify camelCase field names (MCP spec requirement)
- [x] Test backward compatibility (structuredContent omitted when None)
- [x] cargo fmt passes
- [x] cargo clippy passes
- [x] cargo test passes (all 1400+ tests)
- [x] Manual test of MCP serve endpoint

Closes #195

---
Generated with [Claude Code](https://claude.com/claude-code)