### PR TITLE
feat(hooks): Expose CLAUDE_TOOL_USE_ID env var to command hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,7 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "url",
 ]

--- a/crates/cli/src/hooks/executor.rs
+++ b/crates/cli/src/hooks/executor.rs
@@ -143,6 +143,10 @@ impl HookExecutor {
             cmd.env("CLAUDE_TOOL_NAME", tool_name);
         }
 
+        if let Some(tool_use_id) = &context.tool_use_id {
+            cmd.env("CLAUDE_TOOL_USE_ID", tool_use_id);
+        }
+
         if let Some(env_file) = env_file {
             cmd.env("CLAUDE_ENV_FILE", env_file);
         }
@@ -430,5 +434,68 @@ mod tests {
         }
 
         assert!(result[0].is_success());
+    }
+
+    #[tokio::test]
+    async fn test_command_hook_receives_tool_use_id_env_var() {
+        // This test verifies that CLAUDE_TOOL_USE_ID is set for tool-related hooks
+        let hook = Hook::command("echo $CLAUDE_TOOL_USE_ID".to_string(), Some(5000));
+        let context = HookContext::for_tool(
+            "test-session".to_string(),
+            "/tmp/transcript".to_string(),
+            std::env::current_dir()
+                .unwrap()
+                .to_string_lossy()
+                .to_string(),
+            "ask".to_string(),
+            HookEvent::PreToolUse,
+            "Write".to_string(),
+            Some("toolu_test_123".to_string()),
+        );
+
+        let executor = HookExecutor::new();
+        let result = executor.execute_hooks(&[hook], &context).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(result[0].is_success());
+        // Verify the tool_use_id was passed through environment variable
+        assert!(
+            result[0].stdout.trim().contains("toolu_test_123"),
+            "Expected CLAUDE_TOOL_USE_ID to be set. Got stdout: {}",
+            result[0].stdout
+        );
+    }
+
+    #[tokio::test]
+    async fn test_command_hook_tool_use_id_not_set_when_none() {
+        // Verify that CLAUDE_TOOL_USE_ID is NOT set when context has None
+        let hook = Hook::command(
+            "echo \"ID:$CLAUDE_TOOL_USE_ID:END\"".to_string(),
+            Some(5000),
+        );
+        let context = HookContext::for_tool(
+            "test-session".to_string(),
+            "/tmp/transcript".to_string(),
+            std::env::current_dir()
+                .unwrap()
+                .to_string_lossy()
+                .to_string(),
+            "ask".to_string(),
+            HookEvent::PreToolUse,
+            "Write".to_string(),
+            None, // No tool_use_id
+        );
+
+        let executor = HookExecutor::new();
+        let result = executor.execute_hooks(&[hook], &context).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(result[0].is_success());
+        // When tool_use_id is None, the env var should not be set (empty)
+        assert!(
+            result[0].stdout.trim() == "ID::END",
+            "Expected empty CLAUDE_TOOL_USE_ID when None. Got stdout: {}",
+            result[0].stdout
+        );
     }
 }

--- a/docs/HOOK_LIFECYCLE_INTEGRATION.md
+++ b/docs/HOOK_LIFECYCLE_INTEGRATION.md
@@ -1066,6 +1066,7 @@ All command hooks receive:
 - `CLAUDE_PERMISSION_MODE` - Permission mode (auto/ask/always)
 - `CLAUDE_HOOK_EVENT` - Event name (e.g., "PreToolUse")
 - `CLAUDE_TOOL_NAME` - Tool name (for tool-related events)
+- `CLAUDE_TOOL_USE_ID` - Unique identifier for this tool invocation (for PreToolUse/PostToolUse events), allows correlating pre/post hooks for the same tool call
 - `CLAUDE_PROJECT_DIR` - Project root directory
 
 #### Hook Context as JSON


### PR DESCRIPTION
## Summary

- Add `CLAUDE_TOOL_USE_ID` environment variable to command hooks, allowing bash/shell hooks to access the unique tool invocation identifier for PreToolUse and PostToolUse events
- This enables hooks to correlate pre and post tool use events for the same tool call
- Track tool invocations for logging and debugging
- Implement custom tooling that depends on tool use IDs

## Changes

### Core Implementation
- **crates/cli/src/hooks/executor.rs**: Added 3 lines to expose `tool_use_id` as `CLAUDE_TOOL_USE_ID` environment variable when available

### Tests
- Added `test_command_hook_receives_tool_use_id_env_var` - verifies the env var is set when tool_use_id is present
- Added `test_command_hook_tool_use_id_not_set_when_none` - verifies the env var is NOT set when tool_use_id is None

### Documentation
- **docs/HOOK_LIFECYCLE_INTEGRATION.md**: Added documentation for the new `CLAUDE_TOOL_USE_ID` environment variable

## Test Plan

- [x] All 16 tool_use_id related tests pass (8 tests x 2 test targets)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [x] Release build succeeds
- [x] Verify CLAUDE_TOOL_USE_ID is set when tool_use_id is present
- [x] Verify CLAUDE_TOOL_USE_ID is NOT set when tool_use_id is None

Closes #196

🤖 Generated with [Claude Code](https://claude.ai/code)