### PR TITLE
fix: Eliminate TOCTOU race in memory DB schema init

### DIFF
--- a/crates/memory/src/database.rs
+++ b/crates/memory/src/database.rs
@@ -116,10 +116,19 @@ impl Database {
     }
 
     /// Initialize database schema
+    ///
+    /// Uses BEGIN EXCLUSIVE to serialize concurrent schema initialization.
+    /// The version check runs INSIDE the exclusive transaction to prevent
+    /// a TOCTOU race where another process could initialize the schema
+    /// between the version read and the lock acquisition.
     fn initialize_schema(&self) -> Result<()> {
         let conn = self.lock_conn()?;
 
-        // Check if schema exists
+        // Acquire exclusive lock FIRST, then check version inside the transaction
+        // to eliminate the TOCTOU race condition (issue #378).
+        conn.execute_batch("BEGIN EXCLUSIVE")?;
+
+        // Check if schema exists (now safely inside the exclusive transaction)
         let version: i32 = conn
             .query_row(
                 "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1",
@@ -130,13 +139,11 @@ impl Database {
 
         if version >= SCHEMA_VERSION {
             debug!("Schema version {} is current", version);
+            conn.execute_batch("COMMIT")?;
             return Ok(());
         }
 
         info!("Initializing database schema version {}", SCHEMA_VERSION);
-
-        // Wrap schema init in a transaction to avoid races on concurrent first-open
-        conn.execute_batch("BEGIN EXCLUSIVE")?;
 
         // Create schema_version table
         conn.execute(


### PR DESCRIPTION
## Summary

- Moved `BEGIN EXCLUSIVE` before the schema version check in `initialize_schema()` to eliminate a TOCTOU race condition
- Previously, the version was read outside the exclusive transaction, allowing another process to initialize the schema between the read and the lock acquisition
- Now the exclusive lock is acquired first, the version is checked inside the transaction, and an early `COMMIT` exits if the schema is already current

## Test plan

- [x] `cargo check -p rustyclawd-memory` passes clean
- [x] All 39 unit/integration tests pass (`cargo test -p rustyclawd-memory`)
- [x] All 3 doc-tests pass
- [x] Verified the transaction flow: BEGIN EXCLUSIVE -> version check -> conditional schema creation -> COMMIT

Fixes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)