### PR TITLE
fix: Replace blocking sleep with async in subprocess executor

### DIFF
--- a/crates/cli/src/plugins/subprocess.rs
+++ b/crates/cli/src/plugins/subprocess.rs
@@ -291,8 +291,7 @@ mod tests {
     async fn test_timeout_kills_process_tree() {
         // Start a shell that spawns a child process
         // The parent sleeps, and we need to ensure both are killed
-        let result =
-            SubprocessExecutor::execute("sh", &["-c", "sleep 10 & sleep 10"], 200).await;
+        let result = SubprocessExecutor::execute("sh", &["-c", "sleep 10 & sleep 10"], 200).await;
 
         assert!(result.is_ok());
         let exec_result = result.unwrap();


### PR DESCRIPTION
## Summary

- Replaced `std::thread::sleep` with `tokio::time::sleep` in the subprocess executor's polling loop (line 184) and process kill grace period (line 70)
- Made `SubprocessExecutor::execute` and `kill_process` async functions
- Updated all unit tests to use `#[tokio::test]` with `.await`

This prevents blocking the tokio executor thread, which was starving concurrent async tasks whenever a subprocess was running.

Fixes #377