### PR TITLE
fix: HookMatcher dot heuristic, wrong-arch download fallback, scheduler retry interval

### DIFF
--- a/crates/cli/src/hooks/types.rs
+++ b/crates/cli/src/hooks/types.rs
@@ -101,8 +101,10 @@ impl<'de> Deserialize<'de> for HookMatcher {
         if s == "*" {
             // "*" is an exact match that matches everything
             Ok(HookMatcher::Exact(s))
-        } else if s.contains('|') || s.contains(".*") || s.contains(".") {
-            // Contains regex special characters: pipe (alternation), .* (wildcard), dots
+        } else if s.contains('|') || s.contains(".*") {
+            // Contains regex special characters: pipe (alternation) or .* (wildcard)
+            // Note: a bare "." is NOT treated as regex — it's too common in tool
+            // names like "file.read" or "mcp__server__tool.action".
             Ok(HookMatcher::Regex(s))
         } else if is_mcp_server_wildcard(&s) {
             // MCP server wildcard pattern: mcp__<server>__*

--- a/crates/cli/src/update/github_client.rs
+++ b/crates/cli/src/update/github_client.rs
@@ -362,11 +362,7 @@ impl UpdateInfo {
 
         self.assets
             .iter()
-            .find(|asset| {
-                let contains_target =
-                    asset.name.contains(&target) || asset.name.contains("x86_64-unknown-linux");
-                contains_target && has_exe_extension(&asset.name)
-            })
+            .find(|asset| asset.name.contains(&target) && has_exe_extension(&asset.name))
             .map(|asset| asset.browser_download_url.clone())
     }
 }

--- a/crates/cli/src/update/scheduler.rs
+++ b/crates/cli/src/update/scheduler.rs
@@ -105,6 +105,11 @@ impl UpdateScheduler {
 
         info!("Performing scheduled update check");
 
+        // Update the last check timestamp regardless of outcome so that
+        // persistent network errors don't cause a retry on every startup.
+        self.config.update_last_check();
+        self.save_config()?;
+
         // Get update info from GitHub
         let update_info = match github_client.get_update_info(current_version).await {
             Ok(info) => info,
@@ -128,12 +133,6 @@ impl UpdateScheduler {
                 });
             }
         };
-
-        // Update the last check timestamp
-        self.config.update_last_check();
-
-        // Persist the updated config
-        self.save_config()?;
 
         let result = ScheduledCheckResult {
             check_performed: true,


### PR DESCRIPTION
## Summary

- **HookMatcher serde**: Remove bare `.` from regex detection heuristic so tool names like `file.read` are correctly classified as `Exact` instead of `Regex`. Only `|` (alternation) and `.*` (wildcard) now trigger regex mode.
- **get_asset_for_platform**: Remove hardcoded `x86_64-unknown-linux` fallback that silently downloaded the wrong architecture binary on non-x86 platforms. Returns `None` when no matching asset exists.
- **UpdateScheduler**: Move `update_last_check()` before the network call so the check interval is respected even on failure, preventing retry-on-every-startup during persistent network outages.

Partially addresses #379 and #380

## Test plan

- [x] `cargo check` passes
- [x] `cargo test -p rustyclawd-cli --lib` -- all 724 tests pass, 0 failures
- [x] `cargo fmt --all` applied
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)