### PR TITLE
fix: UTF-8 safe truncation, LazyLock over lazy_static, Option<PathBuf> for backup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2548,7 +2548,6 @@ dependencies = [
  "escargot",
  "futures",
  "http",
- "lazy_static",
  "libc",
  "predicates",
  "rat-event",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -51,9 +51,6 @@ serde_yaml = "0.9"
 toml = "0.8"
 dirs = "5.0"
 
-# Terminal state management
-lazy_static = "1.4"
-
 # Update mechanism - Phase 2
 sha2 = "0.10"
 tempfile = "3.8"

--- a/crates/cli/src/terminal_guard.rs
+++ b/crates/cli/src/terminal_guard.rs
@@ -14,7 +14,7 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use std::io::{self, Write};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 
 /// Execution context indicating whether we're running in TUI mode
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -29,11 +29,9 @@ pub enum ExecutionContext {
 // Global execution context
 //
 // This is set once at application startup and read during tool execution.
-// Using lazy_static ensures thread-safe initialization.
-lazy_static::lazy_static! {
-    static ref EXECUTION_CONTEXT: Arc<Mutex<ExecutionContext>> =
-        Arc::new(Mutex::new(ExecutionContext::default()));
-}
+// Using std::sync::LazyLock for thread-safe lazy initialization (stable since Rust 1.80).
+static EXECUTION_CONTEXT: LazyLock<Arc<Mutex<ExecutionContext>>> =
+    LazyLock::new(|| Arc::new(Mutex::new(ExecutionContext::default())));
 
 /// Set the global execution context
 ///

--- a/crates/cli/src/tool_formatter.rs
+++ b/crates/cli/src/tool_formatter.rs
@@ -373,12 +373,21 @@ fn extract_tool_description(tool_name: &str, params: &Value) -> String {
     }
 }
 
-/// Truncate a string to a maximum length, adding ellipsis if needed
+/// Truncate a string to a maximum length, adding ellipsis if needed.
+///
+/// Uses char boundaries to avoid panicking on multi-byte UTF-8 characters.
 fn truncate(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         s.to_string()
     } else {
-        format!("{}...", &s[..max_len.saturating_sub(3)])
+        let budget = max_len.saturating_sub(3);
+        let truncate_at = s
+            .char_indices()
+            .take_while(|(i, c)| i + c.len_utf8() <= budget)
+            .last()
+            .map(|(i, c)| i + c.len_utf8())
+            .unwrap_or(0);
+        format!("{}...", &s[..truncate_at])
     }
 }
 
@@ -464,6 +473,20 @@ mod tests {
     fn test_truncate() {
         assert_eq!(truncate("short", 10), "short");
         assert_eq!(truncate("this is a very long string", 10), "this is...");
+    }
+
+    #[test]
+    fn test_truncate_utf8_multibyte() {
+        // Each emoji is 4 bytes. With max_len=10, budget=7.
+        // Only 1 emoji (4 bytes) fits within 7 bytes, so result is emoji + "..."
+        let emojis = "\u{1F600}\u{1F601}\u{1F602}\u{1F603}"; // 16 bytes total
+        let result = truncate(emojis, 10);
+        assert_eq!(result, "\u{1F600}...");
+
+        // 2-byte chars: each is 2 bytes. budget=7 fits 3 chars (6 bytes).
+        let accented = "\u{00E9}\u{00E9}\u{00E9}\u{00E9}\u{00E9}\u{00E9}"; // 12 bytes
+        let result = truncate(accented, 10);
+        assert_eq!(result.len(), 6 + 3); // 3 chars (6 bytes) + "..." (3 bytes)
     }
 
     #[test]

--- a/crates/cli/src/update/backup.rs
+++ b/crates/cli/src/update/backup.rs
@@ -12,8 +12,8 @@ use tracing::{debug, info};
 /// Represents a single backup entry
 #[derive(Debug, Clone)]
 pub struct BackupEntry {
-    /// Original binary path
-    pub original_path: PathBuf,
+    /// Original binary path (None when recovered from backup listing)
+    pub original_path: Option<PathBuf>,
     /// Backup file path
     pub backup_path: PathBuf,
     /// Timestamp of when the backup was created
@@ -125,7 +125,7 @@ impl BackupManager {
         debug!("Backup created successfully: {:?}", backup_path);
 
         Ok(BackupEntry {
-            original_path: binary_path.to_path_buf(),
+            original_path: Some(binary_path.to_path_buf()),
             backup_path,
             timestamp: now,
             file_size,
@@ -163,7 +163,7 @@ impl BackupManager {
 
                         if let Some(ts) = timestamp {
                             backups.push(BackupEntry {
-                                original_path: PathBuf::new(), // Not available from listing
+                                original_path: None,
                                 backup_path: path,
                                 timestamp: ts,
                                 file_size,
@@ -202,7 +202,7 @@ impl BackupManager {
         })?;
 
         Ok(BackupEntry {
-            original_path: PathBuf::new(),
+            original_path: None,
             backup_path,
             timestamp,
             file_size: metadata.len(),
@@ -331,7 +331,7 @@ mod tests {
     fn test_backup_entry_timestamp_str() {
         let now = Local::now();
         let entry = BackupEntry {
-            original_path: PathBuf::from("/tmp/original"),
+            original_path: Some(PathBuf::from("/tmp/original")),
             backup_path: PathBuf::from("/tmp/backup"),
             timestamp: now,
             file_size: 1024,
@@ -346,7 +346,7 @@ mod tests {
     fn test_backup_entry_filename() {
         let now = Local::now();
         let entry = BackupEntry {
-            original_path: PathBuf::from("/tmp/original"),
+            original_path: Some(PathBuf::from("/tmp/original")),
             backup_path: PathBuf::from("/tmp/backup"),
             timestamp: now,
             file_size: 1024,


### PR DESCRIPTION
## Summary

- **tool_formatter.rs**: Fixed UTF-8 truncation panic by using `char_indices()` to find char-boundary-safe cut points instead of raw byte slicing with `&s[..max_len]`. Added test for multi-byte characters (emoji, accented chars).
- **terminal_guard.rs**: Replaced `lazy_static!` macro with `std::sync::LazyLock` (stable since Rust 1.80). Removed `lazy_static` crate dependency from `Cargo.toml` since it had no other usages in the CLI crate.
- **backup.rs**: Changed `BackupEntry.original_path` from `PathBuf` to `Option<PathBuf>` so that "not available" is expressed as `None` rather than an empty `PathBuf` sentinel value. Updated all construction sites and tests.

Partially addresses #379 and #380.

## Test plan

- [x] `cargo check` passes cleanly
- [x] `cargo test -p rustyclawd-cli --lib` -- all 36 relevant tests pass
- [x] New `test_truncate_utf8_multibyte` test validates multi-byte safety
- [x] `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)