### PR TITLE
fix: TUI cleanup -- static keybindings, cached focus, Clear widget, unicode width

### DIFF
--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -5,7 +5,7 @@ use crate::permission_mode::PermissionMode;
 use crate::tui::message::Message;
 use crate::tui::thinking_state::ThinkingState;
 use crate::tui::token_counter::TokenCount;
-use rat_focus::FocusFlag;
+use rat_focus::{Focus, FocusFlag};
 use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
@@ -361,6 +361,12 @@ pub struct App {
 
     /// Mouse mode enabled (when false, allows terminal text selection)
     mouse_mode_enabled: bool,
+
+    /// Cached focus structure (rebuilt only when focus_dirty is set)
+    cached_focus: Option<Focus>,
+
+    /// Flag indicating focus structure needs rebuilding (debug toggle, modal open/close)
+    focus_dirty: bool,
 }
 
 /// State for active streaming response
@@ -413,6 +419,8 @@ impl App {
             click_regions: crate::tui::click_region::ClickableRegions::new(),
             soft_wrap: SoftWrapState::default(),
             mouse_mode_enabled: true, // Start with mouse mode ON
+            cached_focus: None,
+            focus_dirty: true, // Start dirty to build on first event
         }
     }
 
@@ -1321,6 +1329,7 @@ impl App {
         self.debug_visible = !self.debug_visible;
         let status = if self.debug_visible { "ON" } else { "OFF" };
         self.push_debug_message(format!("=== Debug Panel {} ===", status));
+        self.focus_dirty = true;
         self.mark_dirty();
     }
 
@@ -1456,12 +1465,14 @@ impl App {
         } else {
             self.autocomplete = Some(AutocompleteState { items, selected: 0 });
         }
+        self.focus_dirty = true;
         self.mark_dirty();
     }
 
     /// Clear autocomplete
     pub fn clear_autocomplete(&mut self) {
         self.autocomplete = None;
+        self.focus_dirty = true;
         self.mark_dirty();
     }
 
@@ -1525,6 +1536,7 @@ impl App {
                 selected: 0,
             });
         }
+        self.focus_dirty = true;
         self.mark_dirty();
     }
 
@@ -1539,6 +1551,7 @@ impl App {
     /// Clear memory modal
     pub fn clear_memory_modal(&mut self) {
         self.memory_modal = None;
+        self.focus_dirty = true;
         self.mark_dirty();
     }
 
@@ -1590,12 +1603,14 @@ impl App {
     /// Activate permissions search modal
     pub fn activate_permissions_modal(&mut self) {
         self.permissions_modal = Some(PermissionsSearchState::new());
+        self.focus_dirty = true;
         self.mark_dirty();
     }
 
     /// Clear permissions modal
     pub fn clear_permissions_modal(&mut self) {
         self.permissions_modal = None;
+        self.focus_dirty = true;
         self.mark_dirty();
     }
 
@@ -1648,12 +1663,96 @@ impl App {
 
     /// Update layout cache from render
     pub fn update_layout_cache(&mut self, cache: LayoutCache) {
+        // Invalidate focus when layout areas change (e.g., terminal resize)
+        if self.layout_cache.messages_area != cache.messages_area
+            || self.layout_cache.input_area != cache.input_area
+            || self.layout_cache.debug_area != cache.debug_area
+        {
+            self.focus_dirty = true;
+        }
         self.layout_cache = cache;
     }
 
     /// Get layout cache
     pub fn layout_cache(&self) -> &LayoutCache {
         &self.layout_cache
+    }
+
+    // === Focus caching ===
+
+    /// Mark the focus structure as needing a rebuild
+    pub fn invalidate_focus(&mut self) {
+        self.focus_dirty = true;
+    }
+
+    /// Check if focus needs rebuilding
+    pub fn is_focus_dirty(&self) -> bool {
+        self.focus_dirty
+    }
+
+    /// Get the cached focus, rebuilding if necessary.
+    /// Returns None if layout cache is not initialized (zero-size area).
+    pub fn get_or_rebuild_focus(&mut self) -> Option<&mut Focus> {
+        let cache = self.layout_cache.clone();
+
+        // Skip if layout cache is not initialized
+        if cache.messages_area.width == 0 && cache.messages_area.height == 0 {
+            return None;
+        }
+
+        if self.focus_dirty || self.cached_focus.is_none() {
+            // Rebuild focus structure
+            let mut builder = rat_focus::FocusBuilder::default();
+
+            let messages_wrapper = MessagesPaneWrapper {
+                focus: self.focus_messages.clone(),
+                area: cache.messages_area,
+            };
+            rat_focus::HasFocus::build(&messages_wrapper, &mut builder);
+
+            let input_wrapper = InputPaneWrapper {
+                focus: self.focus_input.clone(),
+                area: cache.input_area,
+            };
+            rat_focus::HasFocus::build(&input_wrapper, &mut builder);
+
+            if let Some(debug_area) = cache.debug_area {
+                let debug_wrapper = DebugPaneWrapper {
+                    focus: self.focus_debug.clone(),
+                    area: debug_area,
+                };
+                rat_focus::HasFocus::build(&debug_wrapper, &mut builder);
+            }
+
+            if self.autocomplete.is_some() {
+                let autocomplete_wrapper = AutocompletePopupWrapper {
+                    focus: self.focus_autocomplete.clone(),
+                    area: cache.input_area,
+                };
+                rat_focus::HasFocus::build(&autocomplete_wrapper, &mut builder);
+            }
+
+            if self.memory_modal.is_some() {
+                let memory_modal_wrapper = MemoryModalWrapper {
+                    focus: self.focus_memory_modal.clone(),
+                    area: cache.input_area,
+                };
+                rat_focus::HasFocus::build(&memory_modal_wrapper, &mut builder);
+            }
+
+            if self.permissions_modal.is_some() {
+                let permissions_modal_wrapper = PermissionsModalWrapper {
+                    focus: self.focus_permissions_modal.clone(),
+                    area: cache.input_area,
+                };
+                rat_focus::HasFocus::build(&permissions_modal_wrapper, &mut builder);
+            }
+
+            self.cached_focus = Some(builder.build());
+            self.focus_dirty = false;
+        }
+
+        self.cached_focus.as_mut()
     }
 }
 

--- a/crates/cli/src/tui/event.rs
+++ b/crates/cli/src/tui/event.rs
@@ -6,14 +6,10 @@ use crossterm::event::{
     KeyModifiers,
 };
 use rat_event::Outcome;
-use rat_focus::{FocusBuilder, HasFocus};
 use std::io;
 use std::time::Duration;
 
-use crate::tui::app::{
-    App, AutocompletePopupWrapper, DebugPaneWrapper, InputPaneWrapper, MemoryModalWrapper,
-    MessagesPaneWrapper, PermissionsModalWrapper,
-};
+use crate::tui::app::App;
 use crate::tui::click_region::ClickTarget;
 use crate::tui::keybindings::{KeyAction, KeyBindings};
 
@@ -56,80 +52,12 @@ pub fn poll_event(timeout: Duration) -> Result<Option<Event>> {
 
 /// Handle a single event, mutating app state
 pub fn handle_event(app: &mut App, event: Event) -> Result<EventResult> {
-    // Build focus structure BEFORE processing events (for Tab/mouse focus handling)
-    // Extract data from app first to avoid borrowing conflicts
-    let cache = app.layout_cache().clone();
-
-    // Only handle focus if layout cache is initialized (non-zero area)
-    // This avoids issues in tests where layout isn't set up
-    if cache.messages_area.width > 0 && cache.messages_area.height > 0 {
-        let focus_messages = app.focus_messages();
-        let focus_input = app.focus_input();
-        let focus_debug = app.focus_debug();
-        let focus_autocomplete = app.focus_autocomplete();
-        let focus_memory_modal = app.focus_memory_modal();
-        let focus_permissions_modal = app.focus_permissions_modal();
-        let autocomplete_active = app.autocomplete_active();
-        let memory_modal_active = app.memory_modal_active();
-        let permissions_modal_active = app.permissions_modal_active();
-
-        let mut builder = FocusBuilder::default();
-
-        // Add panes in z-order (bottom to top)
-        let messages_wrapper = MessagesPaneWrapper {
-            focus: focus_messages,
-            area: cache.messages_area,
-        };
-        messages_wrapper.build(&mut builder);
-
-        let input_wrapper = InputPaneWrapper {
-            focus: focus_input,
-            area: cache.input_area,
-        };
-        input_wrapper.build(&mut builder);
-
-        if let Some(debug_area) = cache.debug_area {
-            let debug_wrapper = DebugPaneWrapper {
-                focus: focus_debug,
-                area: debug_area,
-            };
-            debug_wrapper.build(&mut builder);
-        }
-
-        // Add overlays on top (highest z-order)
-        if autocomplete_active {
-            let autocomplete_wrapper = AutocompletePopupWrapper {
-                focus: focus_autocomplete,
-                // Autocomplete area is calculated in render, use input area as approximation
-                area: cache.input_area,
-            };
-            autocomplete_wrapper.build(&mut builder);
-        }
-
-        if memory_modal_active {
-            let memory_modal_wrapper = MemoryModalWrapper {
-                focus: focus_memory_modal,
-                // Memory modal area is calculated in render, use input area as approximation
-                area: cache.input_area,
-            };
-            memory_modal_wrapper.build(&mut builder);
-        }
-
-        if permissions_modal_active {
-            let permissions_modal_wrapper = PermissionsModalWrapper {
-                focus: focus_permissions_modal,
-                // Permissions modal area is calculated in render, use input area as approximation
-                area: cache.input_area,
-            };
-            permissions_modal_wrapper.build(&mut builder);
-        }
-
-        let mut focus = builder.build();
-
+    // Use cached focus structure (only rebuilt when pane visibility changes)
+    if let Some(focus) = app.get_or_rebuild_focus() {
         // Handle focus events (Tab navigation, mouse clicks) with rat-focus
         // This processes focus changes BEFORE other event handling
         // The FocusFlags will update automatically based on focus changes
-        let focus_outcome = rat_focus::handle_focus(&mut focus, &event);
+        let focus_outcome = rat_focus::handle_focus(focus, &event);
 
         // CRITICAL: Check if rat-focus consumed the event
         // If it did (Tab/mouse click for focus), don't process further
@@ -292,8 +220,8 @@ fn handle_key_event(app: &mut App, key: KeyEvent) -> Result<EventResult> {
         }
     }
 
-    // Get keybindings configuration
-    let bindings = KeyBindings::default();
+    // Get keybindings configuration (static, zero allocation)
+    let bindings = KeyBindings::defaults();
 
     // Try to find a keybinding action for this key
     if let Some(action) = bindings.find_action(&key) {

--- a/crates/cli/src/tui/keybindings.rs
+++ b/crates/cli/src/tui/keybindings.rs
@@ -4,6 +4,7 @@
 //! from bleeding into text input. All control keys are intercepted BEFORE input.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::sync::LazyLock;
 
 /// Action to take when a keybinding is triggered
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -69,7 +70,7 @@ pub enum KeyAction {
 pub struct KeyBinding {
     pub key: KeyPattern,
     pub action: KeyAction,
-    pub description: String,
+    pub description: &'static str,
 }
 
 /// Pattern for matching key events
@@ -179,178 +180,183 @@ pub struct KeyBindings {
     bindings: Vec<KeyBinding>,
 }
 
-impl KeyBindings {
-    /// Create default keybindings
-    pub fn default() -> Self {
-        let bindings = vec![
-            // Exit
-            KeyBinding {
-                key: KeyPattern::ctrl_char('c'),
-                action: KeyAction::Exit,
-                description: "Exit application".to_string(),
+/// Static default keybindings instance. Created once, reused on every keypress.
+static DEFAULT_BINDINGS: LazyLock<KeyBindings> = LazyLock::new(|| {
+    let bindings = vec![
+        // Exit
+        KeyBinding {
+            key: KeyPattern::ctrl_char('c'),
+            action: KeyAction::Exit,
+            description: "Exit application",
+        },
+        KeyBinding {
+            key: KeyPattern::ctrl_char('d'),
+            action: KeyAction::Exit,
+            description: "Exit application",
+        },
+        // Debug panel
+        KeyBinding {
+            key: KeyPattern::f_key(1),
+            action: KeyAction::ToggleDebug,
+            description: "Toggle debug panel",
+        },
+        // Mouse mode
+        KeyBinding {
+            key: KeyPattern::f_key(2),
+            action: KeyAction::ToggleMouseMode,
+            description: "Toggle mouse mode (F2)",
+        },
+        // Permission mode
+        KeyBinding {
+            key: KeyPattern::plain(KeyCodePattern::BackTab),
+            action: KeyAction::CyclePermissionMode,
+            description: "Cycle permission mode (Shift+Tab)",
+        },
+        // Error handling
+        KeyBinding {
+            key: KeyPattern::plain(KeyCodePattern::Esc),
+            action: KeyAction::ClearError,
+            description: "Clear error message",
+        },
+        // Scrolling
+        KeyBinding {
+            key: KeyPattern::plain(KeyCodePattern::Up),
+            action: KeyAction::ScrollUp(1),
+            description: "Scroll up 1 line",
+        },
+        KeyBinding {
+            key: KeyPattern::plain(KeyCodePattern::Down),
+            action: KeyAction::ScrollDown(1),
+            description: "Scroll down 1 line",
+        },
+        // PageUp/PageDown: Jump to input top/bottom (was scroll, now input navigation)
+        KeyBinding {
+            key: KeyPattern::plain(KeyCodePattern::PageUp),
+            action: KeyAction::InputPageUp,
+            description: "Jump to top of input",
+        },
+        KeyBinding {
+            key: KeyPattern::plain(KeyCodePattern::PageDown),
+            action: KeyAction::InputPageDown,
+            description: "Jump to bottom of input",
+        },
+        // Cursor movement (Emacs-style)
+        KeyBinding {
+            key: KeyPattern::ctrl_char('a'),
+            action: KeyAction::CursorStart,
+            description: "Move cursor to start",
+        },
+        KeyBinding {
+            key: KeyPattern::ctrl_char('e'),
+            action: KeyAction::CursorEnd,
+            description: "Move cursor to end",
+        },
+        // Line editing
+        KeyBinding {
+            key: KeyPattern::ctrl_char('u'),
+            action: KeyAction::ClearLine,
+            description: "Clear line",
+        },
+        // Newline insertion (MUST come before plain Enter to match first)
+        // Note: Many terminals strip SHIFT from Enter, so we provide Alt+Enter as fallback
+        KeyBinding {
+            key: KeyPattern::shift(KeyCodePattern::Enter),
+            action: KeyAction::InsertNewline,
+            description: "Insert newline (Shift+Enter)",
+        },
+        KeyBinding {
+            key: KeyPattern {
+                code: KeyCodePattern::Enter,
+                modifiers: KeyModifiers::ALT,
             },
-            KeyBinding {
-                key: KeyPattern::ctrl_char('d'),
-                action: KeyAction::Exit,
-                description: "Exit application".to_string(),
-            },
-            // Debug panel
-            KeyBinding {
-                key: KeyPattern::f_key(1),
-                action: KeyAction::ToggleDebug,
-                description: "Toggle debug panel".to_string(),
-            },
-            // Mouse mode
-            KeyBinding {
-                key: KeyPattern::f_key(2),
-                action: KeyAction::ToggleMouseMode,
-                description: "Toggle mouse mode (F2)".to_string(),
-            },
-            // Permission mode
-            KeyBinding {
-                key: KeyPattern::plain(KeyCodePattern::BackTab),
-                action: KeyAction::CyclePermissionMode,
-                description: "Cycle permission mode (Shift+Tab)".to_string(),
-            },
-            // Error handling
-            KeyBinding {
-                key: KeyPattern::plain(KeyCodePattern::Esc),
-                action: KeyAction::ClearError,
-                description: "Clear error message".to_string(),
-            },
-            // Scrolling
-            KeyBinding {
-                key: KeyPattern::plain(KeyCodePattern::Up),
-                action: KeyAction::ScrollUp(1),
-                description: "Scroll up 1 line".to_string(),
-            },
-            KeyBinding {
-                key: KeyPattern::plain(KeyCodePattern::Down),
-                action: KeyAction::ScrollDown(1),
-                description: "Scroll down 1 line".to_string(),
-            },
-            // PageUp/PageDown: Jump to input top/bottom (was scroll, now input navigation)
-            KeyBinding {
-                key: KeyPattern::plain(KeyCodePattern::PageUp),
-                action: KeyAction::InputPageUp,
-                description: "Jump to top of input".to_string(),
-            },
-            KeyBinding {
-                key: KeyPattern::plain(KeyCodePattern::PageDown),
-                action: KeyAction::InputPageDown,
-                description: "Jump to bottom of input".to_string(),
-            },
-            // Cursor movement (Emacs-style)
-            KeyBinding {
-                key: KeyPattern::ctrl_char('a'),
-                action: KeyAction::CursorStart,
-                description: "Move cursor to start".to_string(),
-            },
-            KeyBinding {
-                key: KeyPattern::ctrl_char('e'),
-                action: KeyAction::CursorEnd,
-                description: "Move cursor to end".to_string(),
-            },
-            // Line editing
-            KeyBinding {
-                key: KeyPattern::ctrl_char('u'),
-                action: KeyAction::ClearLine,
-                description: "Clear line".to_string(),
-            },
-            // Newline insertion (MUST come before plain Enter to match first)
-            // Note: Many terminals strip SHIFT from Enter, so we provide Alt+Enter as fallback
-            KeyBinding {
-                key: KeyPattern::shift(KeyCodePattern::Enter),
-                action: KeyAction::InsertNewline,
-                description: "Insert newline (Shift+Enter)".to_string(),
-            },
-            KeyBinding {
-                key: KeyPattern {
-                    code: KeyCodePattern::Enter,
-                    modifiers: KeyModifiers::ALT,
-                },
-                action: KeyAction::InsertNewline,
-                description: "Insert newline (Alt+Enter)".to_string(),
-            },
-            KeyBinding {
-                key: KeyPattern::ctrl_char('j'),
-                action: KeyAction::InsertNewline,
-                description: "Insert newline (Ctrl+J)".to_string(),
-            },
-            // Input submission
-            KeyBinding {
-                key: KeyPattern::plain(KeyCodePattern::Enter),
-                action: KeyAction::Submit,
-                description: "Submit input".to_string(),
-            },
-            // Basic editing
-            KeyBinding {
-                key: KeyPattern::plain(KeyCodePattern::Backspace),
-                action: KeyAction::Backspace,
-                description: "Delete previous character".to_string(),
-            },
-            KeyBinding {
-                key: KeyPattern::plain(KeyCodePattern::Delete),
-                action: KeyAction::Delete,
-                description: "Delete current character".to_string(),
-            },
-            KeyBinding {
-                key: KeyPattern::plain(KeyCodePattern::Left),
-                action: KeyAction::CursorLeft,
-                description: "Move cursor left".to_string(),
-            },
-            KeyBinding {
-                key: KeyPattern::plain(KeyCodePattern::Right),
-                action: KeyAction::CursorRight,
-                description: "Move cursor right".to_string(),
-            },
-            KeyBinding {
-                key: KeyPattern::plain(KeyCodePattern::Home),
-                action: KeyAction::CursorStart,
-                description: "Move cursor to start".to_string(),
-            },
-            KeyBinding {
-                key: KeyPattern::plain(KeyCodePattern::End),
-                action: KeyAction::CursorEnd,
-                description: "Move cursor to end".to_string(),
-            },
-            // === Multi-line input navigation ===
-            // Word navigation
-            KeyBinding {
-                key: KeyPattern::ctrl(KeyCodePattern::Left),
-                action: KeyAction::CursorWordLeft,
-                description: "Move cursor left by word".to_string(),
-            },
-            KeyBinding {
-                key: KeyPattern::ctrl(KeyCodePattern::Right),
-                action: KeyAction::CursorWordRight,
-                description: "Move cursor right by word".to_string(),
-            },
-            // Absolute navigation
-            KeyBinding {
-                key: KeyPattern::ctrl(KeyCodePattern::Home),
-                action: KeyAction::CursorAbsoluteStart,
-                description: "Jump to start of all input".to_string(),
-            },
-            KeyBinding {
-                key: KeyPattern::ctrl(KeyCodePattern::End),
-                action: KeyAction::CursorAbsoluteEnd,
-                description: "Jump to end of all input".to_string(),
-            },
-            // Viewport scrolling (when input > 5 lines)
-            KeyBinding {
-                key: KeyPattern::ctrl(KeyCodePattern::Up),
-                action: KeyAction::InputScrollUp,
-                description: "Scroll input viewport up".to_string(),
-            },
-            KeyBinding {
-                key: KeyPattern::ctrl(KeyCodePattern::Down),
-                action: KeyAction::InputScrollDown,
-                description: "Scroll input viewport down".to_string(),
-            },
-        ];
+            action: KeyAction::InsertNewline,
+            description: "Insert newline (Alt+Enter)",
+        },
+        KeyBinding {
+            key: KeyPattern::ctrl_char('j'),
+            action: KeyAction::InsertNewline,
+            description: "Insert newline (Ctrl+J)",
+        },
+        // Input submission
+        KeyBinding {
+            key: KeyPattern::plain(KeyCodePattern::Enter),
+            action: KeyAction::Submit,
+            description: "Submit input",
+        },
+        // Basic editing
+        KeyBinding {
+            key: KeyPattern::plain(KeyCodePattern::Backspace),
+            action: KeyAction::Backspace,
+            description: "Delete previous character",
+        },
+        KeyBinding {
+            key: KeyPattern::plain(KeyCodePattern::Delete),
+            action: KeyAction::Delete,
+            description: "Delete current character",
+        },
+        KeyBinding {
+            key: KeyPattern::plain(KeyCodePattern::Left),
+            action: KeyAction::CursorLeft,
+            description: "Move cursor left",
+        },
+        KeyBinding {
+            key: KeyPattern::plain(KeyCodePattern::Right),
+            action: KeyAction::CursorRight,
+            description: "Move cursor right",
+        },
+        KeyBinding {
+            key: KeyPattern::plain(KeyCodePattern::Home),
+            action: KeyAction::CursorStart,
+            description: "Move cursor to start",
+        },
+        KeyBinding {
+            key: KeyPattern::plain(KeyCodePattern::End),
+            action: KeyAction::CursorEnd,
+            description: "Move cursor to end",
+        },
+        // === Multi-line input navigation ===
+        // Word navigation
+        KeyBinding {
+            key: KeyPattern::ctrl(KeyCodePattern::Left),
+            action: KeyAction::CursorWordLeft,
+            description: "Move cursor left by word",
+        },
+        KeyBinding {
+            key: KeyPattern::ctrl(KeyCodePattern::Right),
+            action: KeyAction::CursorWordRight,
+            description: "Move cursor right by word",
+        },
+        // Absolute navigation
+        KeyBinding {
+            key: KeyPattern::ctrl(KeyCodePattern::Home),
+            action: KeyAction::CursorAbsoluteStart,
+            description: "Jump to start of all input",
+        },
+        KeyBinding {
+            key: KeyPattern::ctrl(KeyCodePattern::End),
+            action: KeyAction::CursorAbsoluteEnd,
+            description: "Jump to end of all input",
+        },
+        // Viewport scrolling (when input > 5 lines)
+        KeyBinding {
+            key: KeyPattern::ctrl(KeyCodePattern::Up),
+            action: KeyAction::InputScrollUp,
+            description: "Scroll input viewport up",
+        },
+        KeyBinding {
+            key: KeyPattern::ctrl(KeyCodePattern::Down),
+            action: KeyAction::InputScrollDown,
+            description: "Scroll input viewport down",
+        },
+    ];
 
-        Self { bindings }
+    KeyBindings { bindings }
+});
+
+impl KeyBindings {
+    /// Get the static default keybindings (zero allocation after first call)
+    pub fn defaults() -> &'static KeyBindings {
+        &DEFAULT_BINDINGS
     }
 
     /// Find action for a key event
@@ -407,7 +413,7 @@ mod tests {
 
     #[test]
     fn test_ctrl_c_matches() {
-        let bindings = KeyBindings::default();
+        let bindings = KeyBindings::defaults();
         let event = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
         let action = bindings.find_action(&event);
         assert!(matches!(action, Some(KeyAction::Exit)));
@@ -415,7 +421,7 @@ mod tests {
 
     #[test]
     fn test_f1_matches() {
-        let bindings = KeyBindings::default();
+        let bindings = KeyBindings::defaults();
         let event = KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE);
         let action = bindings.find_action(&event);
         assert!(matches!(action, Some(KeyAction::ToggleDebug)));
@@ -423,21 +429,21 @@ mod tests {
 
     #[test]
     fn test_printable_char() {
-        let bindings = KeyBindings::default();
+        let bindings = KeyBindings::defaults();
         let event = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
         assert!(bindings.is_printable_char(&event));
     }
 
     #[test]
     fn test_control_char_not_printable() {
-        let bindings = KeyBindings::default();
+        let bindings = KeyBindings::defaults();
         let event = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL);
         assert!(!bindings.is_printable_char(&event));
     }
 
     #[test]
     fn test_f_key_is_control() {
-        let bindings = KeyBindings::default();
+        let bindings = KeyBindings::defaults();
         let event = KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE);
         assert!(bindings.is_control_key(&event));
     }

--- a/crates/cli/src/tui/message.rs
+++ b/crates/cli/src/tui/message.rs
@@ -1,6 +1,7 @@
 //! Message types for TUI display
 
 use chrono::{DateTime, Local};
+use unicode_width::UnicodeWidthStr;
 
 /// A message in the conversation
 #[derive(Debug, Clone)]
@@ -189,10 +190,11 @@ impl Message {
             .content
             .lines()
             .map(|line| {
-                if line.is_empty() {
+                let display_width = UnicodeWidthStr::width(line);
+                if display_width == 0 {
                     1
                 } else {
-                    line.len().div_ceil(width)
+                    display_width.div_ceil(width)
                 }
             })
             .sum::<usize>();

--- a/crates/cli/src/tui/ui.rs
+++ b/crates/cli/src/tui/ui.rs
@@ -968,6 +968,10 @@ fn build_memory_list_item(
 
 fn render_permissions_modal(frame: &mut Frame, area: Rect, app: &App) {
     if let Some(state) = app.permissions_modal() {
+        // Clear the full area behind the modal to prevent text bleed-through
+        // (permissions_ui also clears internally, but clearing here ensures
+        // consistency with render_autocomplete and render_memory_modal patterns)
+        frame.render_widget(Clear, area);
         // Use the permissions_ui module to render the modal
         permissions_ui::render_permissions_search(state, area, frame.buffer_mut());
     }


### PR DESCRIPTION
## Summary

- **Static keybindings**: Replaced per-keypress `KeyBindings::default()` allocation (30 heap-allocated Strings) with `LazyLock` static instance via `KeyBindings::defaults()`. Changed `description` field from `String` to `&'static str`.
- **Cached focus structure**: Focus is now built once and cached in `App.cached_focus`, only rebuilt when `focus_dirty` flag is set (debug toggle, modal open/close, layout resize). Eliminates FocusBuilder + 6 wrapper structs per event.
- **Clear widget for permissions modal**: Added `frame.render_widget(Clear, area)` before rendering permissions modal, matching the pattern used by `render_autocomplete` and `render_memory_modal`.
- **Unicode width fix**: Replaced `line.len()` (byte count) with `UnicodeWidthStr::width()` in `Message::display_lines()` for correct column counting with CJK characters and emoji.

Partially addresses #379 and #380

## Test plan

- [x] `cargo check` passes
- [x] `cargo test -p rustyclawd-cli` -- all 23 tests pass
- [x] `cargo fmt --all` applied
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)