### PR TITLE
fix: Update hardcoded model IDs to current Claude 4.x family

### DIFF
--- a/crates/cli/src/hooks/executor.rs
+++ b/crates/cli/src/hooks/executor.rs
@@ -186,10 +186,13 @@ impl HookExecutor {
         let prompt = Self::build_hook_prompt(hook, context);
 
         // Create the LLM request
-        // Use claude-3-haiku-20240307 which is a fast, available model for hooks
-        let request =
-            CreateMessageRequest::new("claude-3-haiku-20240307", vec![Message::user(prompt)], 1024)
-                .with_temperature(0.0); // Use deterministic responses for hooks
+        // Use claude-haiku-4-5-20251001 which is a fast, available model for hooks
+        let request = CreateMessageRequest::new(
+            "claude-haiku-4-5-20251001",
+            vec![Message::user(prompt)],
+            1024,
+        )
+        .with_temperature(0.0); // Use deterministic responses for hooks
 
         // Execute with timeout
         let timeout_duration = Duration::from_millis(hook.effective_timeout() as u64);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1091,12 +1091,12 @@ impl App {
             .model
             .as_ref()
             .map(|m| match m.as_str() {
-                "sonnet" => "claude-sonnet-4-5-20250929",
-                "opus" => "claude-opus-20240229",
-                "haiku" => "claude-3-5-haiku-20241022",
+                "sonnet" => "claude-sonnet-4-6",
+                "opus" => "claude-opus-4-6",
+                "haiku" => "claude-haiku-4-5-20251001",
                 custom => custom,
             })
-            .unwrap_or("claude-sonnet-4-5-20250929")
+            .unwrap_or("claude-sonnet-4-6")
             .to_string();
 
         // Fallback model configuration (if specified)
@@ -1105,9 +1105,9 @@ impl App {
             .fallback_model
             .as_ref()
             .map(|m| match m.as_str() {
-                "sonnet" => "claude-sonnet-4-5-20250929",
-                "opus" => "claude-opus-20240229",
-                "haiku" => "claude-3-5-haiku-20241022",
+                "sonnet" => "claude-sonnet-4-6",
+                "opus" => "claude-opus-4-6",
+                "haiku" => "claude-haiku-4-5-20251001",
                 custom => custom,
             })
             .map(|s| s.to_string());

--- a/crates/tools/src/agent.rs
+++ b/crates/tools/src/agent.rs
@@ -100,11 +100,11 @@ impl AgentTool {
     /// Convert model name to API model ID
     fn resolve_model_id(model_name: Option<&str>) -> String {
         match model_name {
-            Some("haiku") => "claude-3-5-haiku-20241022",
-            Some("sonnet") => "claude-3-5-sonnet-20241022",
-            Some("opus") => "claude-opus-4-20250514",
+            Some("haiku") => "claude-haiku-4-5-20251001",
+            Some("sonnet") => "claude-sonnet-4-6",
+            Some("opus") => "claude-opus-4-6",
             Some(custom) if custom.starts_with("claude-") => custom,
-            _ => "claude-3-5-sonnet-20241022", // Default to sonnet
+            _ => "claude-sonnet-4-6", // Default to sonnet
         }
         .to_string()
     }
@@ -543,20 +543,14 @@ mod tests {
     fn test_model_resolution() {
         assert_eq!(
             AgentTool::resolve_model_id(Some("haiku")),
-            "claude-3-5-haiku-20241022"
+            "claude-haiku-4-5-20251001"
         );
         assert_eq!(
             AgentTool::resolve_model_id(Some("sonnet")),
-            "claude-3-5-sonnet-20241022"
+            "claude-sonnet-4-6"
         );
-        assert_eq!(
-            AgentTool::resolve_model_id(Some("opus")),
-            "claude-opus-4-20250514"
-        );
-        assert_eq!(
-            AgentTool::resolve_model_id(None),
-            "claude-3-5-sonnet-20241022"
-        );
+        assert_eq!(AgentTool::resolve_model_id(Some("opus")), "claude-opus-4-6");
+        assert_eq!(AgentTool::resolve_model_id(None), "claude-sonnet-4-6");
         assert_eq!(
             AgentTool::resolve_model_id(Some("claude-custom-model")),
             "claude-custom-model"

--- a/crates/tools/src/agent/README.md
+++ b/crates/tools/src/agent/README.md
@@ -365,11 +365,11 @@ The tool supports flexible model selection:
 
 | Input | Resolved Model |
 |-------|---------------|
-| `"haiku"` | `claude-3-5-haiku-20241022` |
-| `"sonnet"` | `claude-3-5-sonnet-20241022` |
-| `"opus"` | `claude-opus-4-20250514` |
+| `"haiku"` | `claude-haiku-4-5-20251001` |
+| `"sonnet"` | `claude-sonnet-4-6` |
+| `"opus"` | `claude-opus-4-6` |
 | `"claude-custom-..."` | Custom model ID (pass-through) |
-| `None` | `claude-3-5-sonnet-20241022` (default) |
+| `None` | `claude-sonnet-4-6` (default) |
 
 ## Usage Examples
 

--- a/crates/tools/src/web_search.rs
+++ b/crates/tools/src/web_search.rs
@@ -154,11 +154,7 @@ impl WebSearchTool {
     /// Check if model supports web_search
     fn is_model_supported(model: &str) -> bool {
         // Opus 4, Sonnet 4, Haiku 4 support web_search
-        model.contains("opus-4")
-            || model.contains("sonnet-4")
-            || model.contains("haiku-4")
-            || model.contains("claude-3-5-sonnet")
-            || model.contains("claude-3-opus")
+        model.contains("opus-4") || model.contains("sonnet-4") || model.contains("haiku-4")
     }
 
     /// Build cache key from params
@@ -569,13 +565,10 @@ mod tests {
 
     #[test]
     fn test_model_support_detection() {
-        assert!(WebSearchTool::is_model_supported("claude-opus-4-20250514"));
+        assert!(WebSearchTool::is_model_supported("claude-opus-4-6"));
+        assert!(WebSearchTool::is_model_supported("claude-sonnet-4-6"));
         assert!(WebSearchTool::is_model_supported(
-            "claude-sonnet-4-5-20250929"
-        ));
-        assert!(WebSearchTool::is_model_supported("claude-haiku-4-20250514"));
-        assert!(WebSearchTool::is_model_supported(
-            "claude-3-5-sonnet-20241022"
+            "claude-haiku-4-5-20251001"
         ));
         assert!(!WebSearchTool::is_model_supported("claude-2.1"));
         assert!(!WebSearchTool::is_model_supported("gpt-4"));


### PR DESCRIPTION
## Summary

- Replace stale `claude-3-5-*` and `claude-3-*` hardcoded model IDs with current Claude 4.x family IDs (`claude-haiku-4-5-20251001`, `claude-sonnet-4-6`, `claude-opus-4-6`)
- Updated production model resolution in agent tool, web_search tool, CLI main, and hook executor
- Updated corresponding unit tests and README documentation to match

## Changes

| File | What changed |
|------|-------------|
| `crates/tools/src/agent.rs` | `resolve_model_id()` mappings + test assertions |
| `crates/tools/src/web_search.rs` | Removed stale claude-3-5 fallbacks from `is_model_supported()` + test |
| `crates/cli/src/main.rs` | CLI `--model` / `--fallback-model` resolution and default |
| `crates/cli/src/hooks/executor.rs` | Hook execution model ID |
| `crates/tools/src/agent/README.md` | Documentation table |

## Not changed (intentionally)

Test-only opaque model strings in `crates/cli/src/settings/` and `crates/core/src/client/` -- these use `"claude-3"` as arbitrary test data for settings propagation, not as real model resolution targets.

## Test plan

- [x] `cargo check` passes cleanly
- [x] `cargo fmt --all` applied
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)