### PR TITLE
fix: handle swallowed errors, remove dead code, implement scroll stubs (#443)

### DIFF
--- a/crates/cli/src/interactive.rs
+++ b/crates/cli/src/interactive.rs
@@ -340,12 +340,20 @@ impl InteractiveSession {
             self.tui
                 .push_debug("[TOOL_LOOP] Starting next turn after tools".to_string());
 
-            let _ = conversation::start_streaming_turn(
+            if let Err(e) = conversation::start_streaming_turn(
                 &self.client,
                 &self.model,
                 &mut self.tui,
                 &mut self.streaming,
-            );
+            ) {
+                self.tui
+                    .add_message(crate::tui::ChatMessage::system(format!(
+                        "Failed to start streaming turn: {}",
+                        e
+                    )));
+                self.tui
+                    .push_debug(format!("[TOOL_LOOP] Streaming turn failed: {}", e));
+            }
         }
     }
 

--- a/crates/cli/src/notification.rs
+++ b/crates/cli/src/notification.rs
@@ -13,14 +13,6 @@ use std::sync::Arc;
 // Re-export NotificationType for convenience
 pub use crate::hooks::NotificationType;
 
-/// Sanitize message to prevent terminal injection attacks
-#[allow(dead_code)] // Security utility to be wired into notification display
-fn sanitize_message(msg: &str) -> String {
-    msg.chars()
-        .filter(|c| !c.is_control() || *c == '\n' || *c == '\t')
-        .collect()
-}
-
 /// Notification manager with hook integration
 #[derive(Clone)]
 pub struct NotificationManager {

--- a/crates/cli/src/tui/input_state.rs
+++ b/crates/cli/src/tui/input_state.rs
@@ -283,12 +283,16 @@ impl InputState {
     }
 
     pub fn scroll_input_viewport_up(&mut self) {
-        // TODO: Investigate if TextArea has scroll() method or if auto-handled
-        // For now, no-op (mark_dirty handled by caller)
+        // TextArea auto-scrolls when cursor moves — move cursor up 5 lines to scroll viewport
+        for _ in 0..5 {
+            self.input.move_cursor(tui_textarea::CursorMove::Up);
+        }
     }
 
     pub fn scroll_input_viewport_down(&mut self) {
-        // TODO: Same as above
+        for _ in 0..5 {
+            self.input.move_cursor(tui_textarea::CursorMove::Down);
+        }
     }
 
     /// Clear input without submitting (Ctrl+U behavior)

--- a/crates/cli/src/tui/thinking_state.rs
+++ b/crates/cli/src/tui/thinking_state.rs
@@ -70,7 +70,6 @@ impl ThinkingState {
     }
 
     /// Get current phase
-    #[allow(dead_code)] // Accessor for rendering layer
     pub fn phase(&self) -> ThinkingPhase {
         self.phase
     }

--- a/crates/cli/src/tui/tool_messages.rs
+++ b/crates/cli/src/tui/tool_messages.rs
@@ -67,12 +67,6 @@ impl ToolTracker {
         self.tools.get(tool_id)
     }
 
-    /// Get tool state by tool_id (mutable).
-    #[allow(dead_code)] // Available for future use by App orchestration
-    pub fn get_mut(&mut self, tool_id: &str) -> Option<&mut ToolMessageState> {
-        self.tools.get_mut(tool_id)
-    }
-
     /// Iterate over all active (non-completed) tools.
     pub fn active_tools(&self) -> impl Iterator<Item = (&String, &ToolMessageState)> {
         self.tools.iter().filter(|(_, state)| !state.completed)

--- a/crates/cli/src/tui/tool_renderer.rs
+++ b/crates/cli/src/tui/tool_renderer.rs
@@ -294,13 +294,3 @@ pub fn format_response_content(
 
     lines
 }
-
-/// Truncate output for display (keep last N chars)
-#[allow(dead_code)] // Utility for tool output display
-pub fn truncate_output(output: &str, max_chars: usize) -> String {
-    if output.len() <= max_chars {
-        output.to_string()
-    } else {
-        format!("...{}", &output[output.len() - max_chars..])
-    }
-}

--- a/crates/tools/src/notebook_edit/mod.rs
+++ b/crates/tools/src/notebook_edit/mod.rs
@@ -327,8 +327,8 @@ impl crate::Tool for NotebookEditTool {
                                 "execution_count": null,
                                 "outputs": [],
                             });
-                            if let Some(ref id) = new_cell_id {
-                                cell.as_object_mut().unwrap().insert("id".to_string(), Value::String(id.clone()));
+                            if let (Some(ref id), Some(obj)) = (&new_cell_id, cell.as_object_mut()) {
+                                obj.insert("id".to_string(), Value::String(id.clone()));
                             }
                             cell
                         }
@@ -338,8 +338,8 @@ impl crate::Tool for NotebookEditTool {
                                 "source": new_source.clone(),
                                 "metadata": {},
                             });
-                            if let Some(ref id) = new_cell_id {
-                                cell.as_object_mut().unwrap().insert("id".to_string(), Value::String(id.clone()));
+                            if let (Some(ref id), Some(obj)) = (&new_cell_id, cell.as_object_mut()) {
+                                obj.insert("id".to_string(), Value::String(id.clone()));
                             }
                             cell
                         }


### PR DESCRIPTION
## Summary
P0 bug fixes from quality audit round 8 (#431):

- **Handle swallowed streaming Result** in `interactive.rs:343` — the Result from `conversation::start_streaming_turn()` was silently discarded with `let _`. Now displays error to user and logs to debug panel.
- **Replace unwrap() on user notebook data** in `notebook_edit/mod.rs:331,342` — malformed notebooks could panic the tool executor. Now uses safe if-let pattern.
- **Implement scroll viewport stubs** in `input_state.rs:285-292` — these were no-op functions with TODO comments. Now move cursor 5 lines (TextArea auto-scrolls).
- **Remove dead code** — `sanitize_message()`, `truncate_output()`, `get_mut()`, stale `#[allow(dead_code)]` annotation

## Changes
- 7 files changed, 21 insertions, 34 deletions
- Net reduction: 13 lines removed

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --all-features` — 3108 passed, 0 failed
- [ ] CI checks

Closes #443
Part of #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)