### PR TITLE
test: add 19 tests for critical untested code

### DIFF
--- a/crates/cli/src/tui/input_state.rs
+++ b/crates/cli/src/tui/input_state.rs
@@ -542,3 +542,56 @@ impl InputState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_input_state_empty() {
+        let state = InputState::new();
+        assert!(state.input_text().is_empty());
+        assert_eq!(state.input_line_count(), 1);
+    }
+
+    #[test]
+    fn test_insert_char() {
+        let mut state = InputState::new();
+        state.insert_char('a');
+        state.insert_char('b');
+        assert_eq!(state.input_text(), "ab");
+    }
+
+    #[test]
+    fn test_backspace_empty() {
+        let mut state = InputState::new();
+        // Should not panic
+        let _ = state.backspace();
+        assert!(state.input_text().is_empty());
+    }
+
+    #[test]
+    fn test_submit_input_returns_text() {
+        let mut state = InputState::new();
+        state.insert_char('h');
+        state.insert_char('i');
+        let result = state.submit_input();
+        assert_eq!(result, Some("hi".to_string()));
+        assert!(state.input_text().is_empty());
+    }
+
+    #[test]
+    fn test_submit_empty_returns_none() {
+        let mut state = InputState::new();
+        let result = state.submit_input();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_clear_input() {
+        let mut state = InputState::new();
+        state.insert_char('x');
+        state.clear_input();
+        assert!(state.input_text().is_empty());
+    }
+}

--- a/crates/memory/src/query_builder.rs
+++ b/crates/memory/src/query_builder.rs
@@ -112,3 +112,93 @@ pub(crate) fn execute_query(
     debug!("Query returned {} entries", entries.len());
     Ok(entries)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::Database;
+    use crate::types::{MemoryQuery, MemoryScope, MemoryType};
+    use tempfile::TempDir;
+
+    fn setup_test_db() -> (Database, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        (db, temp_dir)
+    }
+
+    #[test]
+    fn test_escape_like_special_chars() {
+        assert_eq!(escape_like("hello%world"), "hello\\%world");
+        assert_eq!(escape_like("under_score"), "under\\_score");
+        assert_eq!(escape_like("back\\slash"), "back\\\\slash");
+        assert_eq!(escape_like("normal"), "normal");
+    }
+
+    #[test]
+    fn test_query_empty_filters() {
+        let (db, _dir) = setup_test_db();
+        // Store an entry
+        let entry = MemoryEntry::new(
+            "test_agent",
+            "test",
+            "content",
+            MemoryType::Decision,
+            MemoryScope::Local,
+        );
+        db.store(&entry).unwrap();
+
+        let query = MemoryQuery::default();
+        let results = db.query(&query).unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn test_query_with_search_filter() {
+        let (db, _dir) = setup_test_db();
+        db.store(&MemoryEntry::new(
+            "agent",
+            "findme",
+            "search content",
+            MemoryType::Decision,
+            MemoryScope::Local,
+        ))
+        .unwrap();
+        db.store(&MemoryEntry::new(
+            "agent",
+            "other",
+            "different stuff",
+            MemoryType::Decision,
+            MemoryScope::Local,
+        ))
+        .unwrap();
+
+        let query = MemoryQuery::default().search("findme");
+        let results = db.query(&query).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "findme");
+    }
+
+    #[test]
+    fn test_query_limit_and_offset() {
+        let (db, _dir) = setup_test_db();
+        for i in 0..5 {
+            db.store(&MemoryEntry::new(
+                "agent",
+                format!("entry{}", i),
+                "content",
+                MemoryType::Decision,
+                MemoryScope::Local,
+            ))
+            .unwrap();
+        }
+
+        let query = MemoryQuery::default().limit(2);
+        let results = db.query(&query).unwrap();
+        assert_eq!(results.len(), 2);
+
+        let query = MemoryQuery::default().limit(2).offset(3);
+        let results = db.query(&query).unwrap();
+        assert!(results.len() <= 2);
+    }
+}

--- a/crates/tools/src/bash.rs
+++ b/crates/tools/src/bash.rs
@@ -324,4 +324,73 @@ mod tests {
             assert_eq!(output.exit_code, Some(42));
         }
     }
+
+    #[tokio::test]
+    async fn test_bash_empty_command() {
+        let tool = BashTool;
+        let params = BashParams {
+            command: String::new(),
+            timeout: 5000,
+            description: None,
+            run_in_background: false,
+        };
+        let ctx = ToolContext::default();
+        let stream = tool.execute(params, &ctx).await.unwrap();
+        let output: Vec<_> = stream.collect().await;
+        // Empty command should succeed (bash -c "" exits 0)
+        assert!(output
+            .iter()
+            .any(|e| matches!(e, ToolEvent::Result(o) if o.success)));
+    }
+
+    #[tokio::test]
+    async fn test_bash_exit_code_propagated() {
+        let tool = BashTool;
+        let params = BashParams {
+            command: "exit 42".to_string(),
+            timeout: 5000,
+            description: None,
+            run_in_background: false,
+        };
+        let ctx = ToolContext::default();
+        let stream = tool.execute(params, &ctx).await.unwrap();
+        let output: Vec<_> = stream.collect().await;
+        let finished = output
+            .iter()
+            .find_map(|e| {
+                if let ToolEvent::Result(o) = e {
+                    Some(o)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+        assert_eq!(finished.exit_code, Some(42));
+    }
+
+    #[tokio::test]
+    async fn test_bash_stderr_captured() {
+        let tool = BashTool;
+        let params = BashParams {
+            command: "echo stdout_msg && echo stderr_msg >&2".to_string(),
+            timeout: 5000,
+            description: None,
+            run_in_background: false,
+        };
+        let ctx = ToolContext::default();
+        let stream = tool.execute(params, &ctx).await.unwrap();
+        let output: Vec<_> = stream.collect().await;
+        let finished = output
+            .iter()
+            .find_map(|e| {
+                if let ToolEvent::Result(o) = e {
+                    Some(o)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+        assert!(finished.stdout.as_ref().unwrap().contains("stdout_msg"));
+        assert!(finished.stderr.as_ref().unwrap().contains("stderr_msg"));
+    }
 }

--- a/crates/tools/src/edit.rs
+++ b/crates/tools/src/edit.rs
@@ -309,4 +309,40 @@ mod tests {
         let has_error = events.iter().any(|e| matches!(e, ToolEvent::Error { .. }));
         assert!(has_error);
     }
+
+    #[tokio::test]
+    async fn test_edit_file_not_found() {
+        let tool = EditTool;
+        let params = EditParams {
+            file_path: "/tmp/nonexistent_edit_test_file_12345.rs".to_string(),
+            old_string: "foo".to_string(),
+            new_string: "bar".to_string(),
+            replace_all: false,
+        };
+        let ctx = ToolContext::default();
+        let stream = tool.execute(params, &ctx).await.unwrap();
+        let output: Vec<_> = stream.collect().await;
+        // Should return error, not panic
+        assert!(output.iter().any(|e| matches!(e, ToolEvent::Error { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_edit_non_unique_match_error() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        writeln!(temp_file, "duplicate text").unwrap();
+        writeln!(temp_file, "other line").unwrap();
+        writeln!(temp_file, "duplicate text").unwrap();
+        temp_file.flush().unwrap();
+        let params = EditParams {
+            file_path: temp_file.path().to_str().unwrap().to_string(),
+            old_string: "duplicate text".to_string(),
+            new_string: "replaced".to_string(),
+            replace_all: false,
+        };
+        let ctx = ToolContext::default();
+        let stream = EditTool.execute(params, &ctx).await.unwrap();
+        let output: Vec<_> = stream.collect().await;
+        // Should fail because old_string appears twice
+        assert!(output.iter().any(|e| matches!(e, ToolEvent::Error { .. })));
+    }
 }

--- a/crates/tools/src/read.rs
+++ b/crates/tools/src/read.rs
@@ -284,4 +284,33 @@ mod tests {
         let has_error = events.iter().any(|e| matches!(e, ToolEvent::Error { .. }));
         assert!(has_error);
     }
+
+    #[tokio::test]
+    async fn test_read_file_not_found() {
+        let tool = ReadTool;
+        let params = ReadParams {
+            file_path: "/tmp/nonexistent_read_test_file_12345.rs".to_string(),
+            offset: None,
+            limit: None,
+        };
+        let ctx = ToolContext::default();
+        let stream = tool.execute(params, &ctx).await.unwrap();
+        let output: Vec<_> = stream.collect().await;
+        assert!(output.iter().any(|e| matches!(e, ToolEvent::Error { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_read_empty_file() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let params = ReadParams {
+            file_path: temp_file.path().to_str().unwrap().to_string(),
+            offset: None,
+            limit: None,
+        };
+        let ctx = ToolContext::default();
+        let stream = ReadTool.execute(params, &ctx).await.unwrap();
+        let output: Vec<_> = stream.collect().await;
+        // Empty file should succeed, not error
+        assert!(output.iter().any(|e| matches!(e, ToolEvent::Result(_))));
+    }
 }

--- a/crates/tools/src/write.rs
+++ b/crates/tools/src/write.rs
@@ -253,4 +253,36 @@ mod tests {
         let content = tokio::fs::read_to_string(&file_path).await.unwrap();
         assert_eq!(content, "Nested file");
     }
+
+    #[tokio::test]
+    async fn test_write_creates_deep_parent_directories() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("a/b/c/deep.txt");
+        let params = WriteParams {
+            file_path: file_path.to_str().unwrap().to_string(),
+            content: "deep content".to_string(),
+        };
+        let ctx = ToolContext::default();
+        let stream = WriteTool.execute(params, &ctx).await.unwrap();
+        let output: Vec<_> = stream.collect().await;
+        assert!(output.iter().any(|e| matches!(e, ToolEvent::Result(_))));
+        let content = tokio::fs::read_to_string(&file_path).await.unwrap();
+        assert_eq!(content, "deep content");
+    }
+
+    #[tokio::test]
+    async fn test_write_empty_content() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("empty.txt");
+        let params = WriteParams {
+            file_path: file_path.to_str().unwrap().to_string(),
+            content: String::new(),
+        };
+        let ctx = ToolContext::default();
+        let stream = WriteTool.execute(params, &ctx).await.unwrap();
+        let output: Vec<_> = stream.collect().await;
+        assert!(output.iter().any(|e| matches!(e, ToolEvent::Result(_))));
+        let content = tokio::fs::read_to_string(&file_path).await.unwrap();
+        assert!(content.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary
- Adds 19 new tests across 6 files covering critical untested tool and module code
- Tests BashTool (empty command, exit code propagation, stderr capture), EditTool (file not found, non-unique match), ReadTool (file not found, empty file), WriteTool (deep parent dirs, empty content), query_builder (escape_like, empty filters, search filter, limit/offset), and InputState (new state, insert, backspace, submit, clear)
- All 19 tests pass alongside the existing 3000+ test suite with zero failures

## Test plan
- [x] `cargo check --all-features` passes
- [x] `cargo test --all-features` passes (0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

Closes #444

Generated with [Claude Code](https://claude.com/claude-code)