### PR TITLE
fix: add settle delay to SubagentStop hook tests (#440)

### DIFF
--- a/crates/cli/tests/notification_integration_tests.rs
+++ b/crates/cli/tests/notification_integration_tests.rs
@@ -717,6 +717,9 @@ async fn test_subagentstop_hook_fires_with_real_agent() {
         .await
         .unwrap();
 
+    // Allow async hook execution to settle (matches pattern from other tests in this file)
+    tokio::time::sleep(tokio::time::Duration::from_millis(HOOK_EXECUTION_SETTLE_MS)).await;
+
     // THEN: Hook should fire after agent completion
     assert_eq!(results.len(), 1, "Should execute one hook");
     assert!(results[0].is_success(), "Hook should succeed");
@@ -768,6 +771,9 @@ async fn test_subagentstop_hook_receives_agent_context() {
         .execute_hooks(HookEvent::SubagentStop, &context)
         .await
         .unwrap();
+
+    // Allow async hook execution to settle
+    tokio::time::sleep(tokio::time::Duration::from_millis(HOOK_EXECUTION_SETTLE_MS)).await;
 
     // THEN: Hook receives correct agent context via environment variables
     assert!(results[0].is_success());


### PR DESCRIPTION
## Summary
- Add `HOOK_EXECUTION_SETTLE_MS` delay to both SubagentStop hook tests
- Matches the pattern already used by other tests in the same file (e.g., line 294)
- Verified 10/10 passes with parallel test execution

## Root Cause
The shell subprocess (`echo ... > file`) may not complete filesystem write before assertions check for the tracking file, causing intermittent failures under parallel test execution.

## Test plan
- [x] 10/10 consecutive passes with default parallel test threads
- [x] 15/15 tests in notification_integration_tests pass

Closes #440
Part of #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)