### PR TITLE
refactor: extract shared skill discovery module (#432)

### DIFF
--- a/crates/tools/src/command_skill.rs
+++ b/crates/tools/src/command_skill.rs
@@ -8,11 +8,12 @@
 //! The unified tool automatically detects the type based on input format
 //! and searches the appropriate locations.
 
+use crate::skill_discovery;
 use crate::{ToolContext, ToolEvent, ToolMetadata, ToolResult, ToolStream};
 use async_stream::stream;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use tokio::fs;
 use tracing::{debug, warn};
 
@@ -181,7 +182,7 @@ impl crate::Tool for CommandSkillTool {
 
                     match fs::read_to_string(&path).await {
                         Ok(content) => {
-                            let parsed = parse_file(&content, path);
+                            let parsed = skill_discovery::parse_file(&content, path);
 
                             if !parsed.prompt.is_empty() {
                                 found = true;
@@ -190,7 +191,7 @@ impl crate::Tool for CommandSkillTool {
                                 // Apply argument substitution for commands
                                 prompt = apply_argument_substitution(&parsed.prompt, args.as_deref());
                                 found_path = Some(path.display().to_string());
-                                metadata = parsed.metadata;
+                                metadata = parsed.metadata.and_then(|v| serde_yaml::from_value(v).ok());
 
                                 if debug_mode {
                                     debug!(
@@ -218,7 +219,7 @@ impl crate::Tool for CommandSkillTool {
                     percentage: Some(60.0),
                 };
 
-                let skill_paths = discover_skill_paths(&name);
+                let skill_paths = skill_discovery::discover_skill_paths(&name);
 
                 if debug_mode {
                     debug!(
@@ -235,14 +236,14 @@ impl crate::Tool for CommandSkillTool {
 
                     match fs::read_to_string(&path).await {
                         Ok(content) => {
-                            let parsed = parse_file(&content, path);
+                            let parsed = skill_discovery::parse_file(&content, path);
 
                             if !parsed.prompt.is_empty() {
                                 found = true;
                                 command_type = CommandType::Skill;
                                 prompt = parsed.prompt;
                                 found_path = Some(path.display().to_string());
-                                metadata = parsed.metadata;
+                                metadata = parsed.metadata.and_then(|v| serde_yaml::from_value(v).ok());
 
                                 if debug_mode {
                                     debug!(
@@ -282,7 +283,7 @@ impl crate::Tool for CommandSkillTool {
 
                 if !force_command {
                     searched_paths.extend(
-                        discover_skill_paths(&name)
+                        skill_discovery::discover_skill_paths(&name)
                             .iter()
                             .map(|p| format!("  - {} (skill)", p.display()))
                     );
@@ -315,12 +316,6 @@ impl crate::Tool for CommandSkillTool {
     fn is_concurrency_safe(&self) -> bool {
         true
     }
-}
-
-/// Parsed file data
-struct ParsedFile {
-    prompt: String,
-    metadata: Option<CommandSkillMetadata>,
 }
 
 /// Parse input to extract name, args, and whether it's a slash command
@@ -370,128 +365,6 @@ fn discover_command_paths(name: &str) -> Vec<PathBuf> {
     }
 
     paths
-}
-
-/// Discover skill paths for a given name
-fn discover_skill_paths(skill_name: &str) -> Vec<PathBuf> {
-    let mut paths = Vec::new();
-
-    // Support fully-qualified names (e.g., "plugin-name:skill-name")
-    let (plugin, skill) = if skill_name.contains(':') {
-        let parts: Vec<&str> = skill_name.splitn(2, ':').collect();
-        (Some(parts[0]), parts[1])
-    } else {
-        (None, skill_name)
-    };
-
-    // Priority 1: Project-level skills
-    paths.push(PathBuf::from(format!(".claude/skills/{}.md", skill)));
-    paths.push(PathBuf::from(format!(".claude/skills/{}/skill.md", skill)));
-    paths.push(PathBuf::from(format!(".claude/skills/{}/SKILL.md", skill)));
-    paths.push(PathBuf::from(format!(".claude/skills/{}.yaml", skill)));
-    paths.push(PathBuf::from(format!(
-        ".claude/skills/{}/skill.yaml",
-        skill
-    )));
-
-    // Priority 2: User-level skills
-    if let Some(home) = std::env::var_os("HOME") {
-        let home_path = PathBuf::from(home);
-        paths.push(home_path.join(format!(".claude/skills/{}.md", skill)));
-        paths.push(home_path.join(format!(".claude/skills/{}/skill.md", skill)));
-        paths.push(home_path.join(format!(".claude/skills/{}.yaml", skill)));
-        paths.push(home_path.join(format!(".claude/skills/{}/skill.yaml", skill)));
-    }
-
-    // Priority 3: Plugin-specific skills
-    if let Some(plugin_name) = plugin {
-        paths.push(PathBuf::from(format!(
-            ".claude/plugins/{}/skills/{}.md",
-            plugin_name, skill
-        )));
-        paths.push(PathBuf::from(format!(
-            ".claude/plugins/{}/skills/{}/skill.md",
-            plugin_name, skill
-        )));
-        paths.push(PathBuf::from(format!(
-            ".claude/plugins/{}/skills/{}.yaml",
-            plugin_name, skill
-        )));
-    }
-
-    // Priority 4: Example plugins (for development)
-    paths.push(PathBuf::from(format!(
-        "examples/plugins/example-plugin/skills/{}.md",
-        skill
-    )));
-    paths.push(PathBuf::from(format!(
-        "examples/plugins/example-plugin/skills/{}/skill.md",
-        skill
-    )));
-
-    paths
-}
-
-/// Parse a file and extract prompt and metadata
-fn parse_file(content: &str, path: &Path) -> ParsedFile {
-    let extension = path.extension().and_then(|s| s.to_str());
-
-    match extension {
-        Some("md") => parse_markdown_file(content),
-        Some("yaml") | Some("yml") => parse_yaml_file(content),
-        _ => ParsedFile {
-            prompt: content.to_string(),
-            metadata: None,
-        },
-    }
-}
-
-/// Parse a markdown file with optional YAML frontmatter
-fn parse_markdown_file(content: &str) -> ParsedFile {
-    if let Some(stripped) = content.strip_prefix("---") {
-        // Has YAML frontmatter
-        if let Some(end_idx) = stripped.find("---") {
-            let frontmatter = &stripped[..end_idx];
-            let prompt = stripped[end_idx + 3..].trim().to_string();
-
-            // Parse frontmatter as YAML
-            let metadata = serde_yaml::from_str::<CommandSkillMetadata>(frontmatter).ok();
-
-            return ParsedFile { prompt, metadata };
-        }
-    }
-
-    // No frontmatter, use content as-is
-    ParsedFile {
-        prompt: content.to_string(),
-        metadata: None,
-    }
-}
-
-/// Parse a YAML file
-fn parse_yaml_file(content: &str) -> ParsedFile {
-    if let Ok(yaml_value) = serde_yaml::from_str::<serde_yaml::Value>(content) {
-        // Extract prompt from various possible fields
-        let prompt = if let Some(prompt_val) = yaml_value
-            .get("prompt")
-            .or_else(|| yaml_value.get("instructions"))
-            .or_else(|| yaml_value.get("content"))
-        {
-            prompt_val.as_str().unwrap_or(content).to_string()
-        } else {
-            content.to_string()
-        };
-
-        // Try to parse metadata from the YAML
-        let metadata = serde_yaml::from_value::<CommandSkillMetadata>(yaml_value).ok();
-
-        ParsedFile { prompt, metadata }
-    } else {
-        ParsedFile {
-            prompt: content.to_string(),
-            metadata: None,
-        }
-    }
 }
 
 /// Apply argument substitution to a prompt
@@ -615,7 +488,7 @@ mod tests {
 
     #[test]
     fn test_discover_skill_paths() {
-        let paths = discover_skill_paths("code-reviewer");
+        let paths = skill_discovery::discover_skill_paths("code-reviewer");
         assert!(paths.iter().any(|p| p
             .to_str()
             .unwrap()
@@ -628,7 +501,7 @@ mod tests {
 
     #[test]
     fn test_discover_skill_paths_with_plugin() {
-        let paths = discover_skill_paths("my-plugin:my-skill");
+        let paths = skill_discovery::discover_skill_paths("my-plugin:my-skill");
         assert!(paths.iter().any(|p| p
             .to_str()
             .unwrap()
@@ -638,7 +511,7 @@ mod tests {
     #[test]
     fn test_parse_markdown_file_no_frontmatter() {
         let content = "# Simple Content\n\nJust text.";
-        let parsed = parse_markdown_file(content);
+        let parsed = skill_discovery::parse_markdown_file(content);
         assert_eq!(parsed.prompt, content);
         assert!(parsed.metadata.is_none());
     }
@@ -653,11 +526,11 @@ version: 1.0.0
 # Test Content
 
 The actual prompt."#;
-        let parsed = parse_markdown_file(content);
+        let parsed = skill_discovery::parse_markdown_file(content);
         assert!(parsed.prompt.contains("Test Content"));
         assert!(!parsed.prompt.contains("---"));
         assert!(parsed.metadata.is_some());
-        let meta = parsed.metadata.unwrap();
+        let meta: CommandSkillMetadata = serde_yaml::from_value(parsed.metadata.unwrap()).unwrap();
         assert_eq!(meta.description, Some("Test command".to_string()));
         assert_eq!(meta.version, Some("1.0.0".to_string()));
     }
@@ -670,7 +543,7 @@ version: 2.0.0
 prompt: |
   This is the prompt content.
 "#;
-        let parsed = parse_yaml_file(content);
+        let parsed = skill_discovery::parse_yaml_file(content);
         assert!(parsed.prompt.contains("prompt content"));
         assert!(parsed.metadata.is_some());
     }

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -24,6 +24,7 @@ pub mod process_isolation;
 pub mod process_registry;
 pub mod read;
 pub mod skill;
+pub mod skill_discovery;
 pub mod slash_command;
 pub mod task;
 pub mod todo_write;

--- a/crates/tools/src/skill.rs
+++ b/crates/tools/src/skill.rs
@@ -6,11 +6,12 @@
 //! - Multiple skill file format support (markdown, YAML)
 //! - Skill discovery from filesystem
 
+use crate::skill_discovery;
 use crate::{ToolContext, ToolEvent, ToolMetadata, ToolResult, ToolStream};
 use async_stream::stream;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use tokio::fs;
 use tracing::{debug, warn};
 
@@ -92,7 +93,7 @@ impl crate::Tool for SkillTool {
             };
 
             // Discover all possible skill locations
-            let skill_paths = discover_skill_paths(&skill);
+            let skill_paths = skill_discovery::discover_skill_paths(&skill);
 
             if debug {
                 debug!(skill = %skill, path_count = skill_paths.len(), "Searching for skill in {} locations", skill_paths.len());
@@ -121,13 +122,13 @@ impl crate::Tool for SkillTool {
                         }
 
                         // Parse the skill file
-                        let parsed = parse_skill_file(&content, path);
+                        let parsed = skill_discovery::parse_file(&content, path);
 
                         if !parsed.prompt.is_empty() {
                             found = true;
                             prompt = parsed.prompt;
                             found_path = Some(path.display().to_string());
-                            metadata = parsed.metadata;
+                            metadata = parsed.metadata.and_then(|v| serde_yaml::from_value(v).ok());
 
                             if debug {
                                 debug!(
@@ -194,12 +195,6 @@ impl crate::Tool for SkillTool {
     }
 }
 
-/// Parsed skill file data
-struct ParsedSkill {
-    prompt: String,
-    metadata: Option<SkillMetadata>,
-}
-
 /// Load skill content by name, searching all standard skill locations.
 ///
 /// Returns `Some(content)` if a skill with the given name is found, `None` otherwise.
@@ -220,7 +215,7 @@ pub async fn load_skill_content(skill_name: &str) -> Option<String> {
         return None;
     }
 
-    let paths = discover_skill_paths(skill_name);
+    let paths = skill_discovery::discover_skill_paths(skill_name);
 
     for path in &paths {
         if !path.exists() {
@@ -229,7 +224,7 @@ pub async fn load_skill_content(skill_name: &str) -> Option<String> {
 
         match fs::read_to_string(path).await {
             Ok(content) => {
-                let parsed = parse_skill_file(&content, path);
+                let parsed = skill_discovery::parse_file(&content, path);
                 if !parsed.prompt.is_empty() {
                     return Some(parsed.prompt);
                 }
@@ -292,129 +287,6 @@ pub async fn list_available_skills() -> Vec<String> {
     }
 
     skill_names.into_iter().collect()
-}
-
-/// Discover all possible paths where a skill might be located
-pub fn discover_skill_paths(skill_name: &str) -> Vec<PathBuf> {
-    let mut paths = Vec::new();
-
-    // Support fully-qualified names (e.g., "plugin-name:skill-name")
-    let (plugin, skill) = if skill_name.contains(':') {
-        let parts: Vec<&str> = skill_name.splitn(2, ':').collect();
-        (Some(parts[0]), parts[1])
-    } else {
-        (None, skill_name)
-    };
-
-    // Priority 1: Project-level skills in .claude/skills/
-    paths.push(PathBuf::from(format!(".claude/skills/{}.md", skill)));
-    paths.push(PathBuf::from(format!(".claude/skills/{}/skill.md", skill)));
-    paths.push(PathBuf::from(format!(".claude/skills/{}.yaml", skill)));
-    paths.push(PathBuf::from(format!(
-        ".claude/skills/{}/skill.yaml",
-        skill
-    )));
-
-    // Priority 2: User-level skills in ~/.claude/skills/
-    if let Some(home) = std::env::var_os("HOME") {
-        let home_path = PathBuf::from(home);
-        paths.push(home_path.join(format!(".claude/skills/{}.md", skill)));
-        paths.push(home_path.join(format!(".claude/skills/{}/skill.md", skill)));
-        paths.push(home_path.join(format!(".claude/skills/{}.yaml", skill)));
-        paths.push(home_path.join(format!(".claude/skills/{}/skill.yaml", skill)));
-    }
-
-    // Priority 3: Plugin-specific skills
-    if let Some(plugin_name) = plugin {
-        paths.push(PathBuf::from(format!(
-            ".claude/plugins/{}/skills/{}.md",
-            plugin_name, skill
-        )));
-        paths.push(PathBuf::from(format!(
-            ".claude/plugins/{}/skills/{}/skill.md",
-            plugin_name, skill
-        )));
-        paths.push(PathBuf::from(format!(
-            ".claude/plugins/{}/skills/{}.yaml",
-            plugin_name, skill
-        )));
-    }
-
-    // Priority 4: Example plugins (for testing/development)
-    paths.push(PathBuf::from(format!(
-        "examples/plugins/example-plugin/skills/{}.md",
-        skill
-    )));
-    paths.push(PathBuf::from(format!(
-        "examples/plugins/example-plugin/skills/{}/skill.md",
-        skill
-    )));
-
-    paths
-}
-
-/// Parse a skill file and extract prompt and metadata
-fn parse_skill_file(content: &str, path: &Path) -> ParsedSkill {
-    let extension = path.extension().and_then(|s| s.to_str());
-
-    match extension {
-        Some("md") => parse_markdown_skill(content),
-        Some("yaml") | Some("yml") => parse_yaml_skill(content),
-        _ => ParsedSkill {
-            prompt: content.to_string(),
-            metadata: None,
-        },
-    }
-}
-
-/// Parse a markdown skill file with optional YAML frontmatter
-fn parse_markdown_skill(content: &str) -> ParsedSkill {
-    if let Some(stripped) = content.strip_prefix("---") {
-        // Has YAML frontmatter
-        if let Some(end_idx) = stripped.find("---") {
-            let frontmatter = &stripped[..end_idx];
-            let prompt = stripped[end_idx + 3..].trim().to_string();
-
-            // Parse frontmatter as YAML
-            let metadata = serde_yaml::from_str::<SkillMetadata>(frontmatter).ok();
-
-            return ParsedSkill { prompt, metadata };
-        }
-    }
-
-    // No frontmatter, use content as-is
-    ParsedSkill {
-        prompt: content.to_string(),
-        metadata: None,
-    }
-}
-
-/// Parse a YAML skill file
-fn parse_yaml_skill(content: &str) -> ParsedSkill {
-    // First, try to parse as generic YAML value
-    if let Ok(yaml_value) = serde_yaml::from_str::<serde_yaml::Value>(content) {
-        // Extract prompt from various possible fields
-        let prompt = if let Some(prompt_val) = yaml_value
-            .get("prompt")
-            .or_else(|| yaml_value.get("instructions"))
-            .or_else(|| yaml_value.get("content"))
-        {
-            prompt_val.as_str().unwrap_or(content).to_string()
-        } else {
-            content.to_string()
-        };
-
-        // Try to parse metadata from the YAML
-        let metadata = serde_yaml::from_value::<SkillMetadata>(yaml_value).ok();
-
-        ParsedSkill { prompt, metadata }
-    } else {
-        // Failed to parse YAML, use as-is
-        ParsedSkill {
-            prompt: content.to_string(),
-            metadata: None,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -581,7 +453,7 @@ prompt: |
 
     #[tokio::test]
     async fn test_skill_discovery_paths() {
-        let paths = discover_skill_paths("my-skill");
+        let paths = skill_discovery::discover_skill_paths("my-skill");
 
         // Should include project-level paths
         assert!(paths
@@ -606,7 +478,7 @@ prompt: |
 
     #[tokio::test]
     async fn test_skill_with_plugin_prefix() {
-        let paths = discover_skill_paths("example-plugin:code-reviewer");
+        let paths = skill_discovery::discover_skill_paths("example-plugin:code-reviewer");
 
         // Should include plugin-specific paths
         assert!(paths.iter().any(|p| p
@@ -618,7 +490,7 @@ prompt: |
     #[tokio::test]
     async fn test_parse_markdown_skill_no_frontmatter() {
         let content = "# Simple Skill\n\nJust content, no frontmatter.";
-        let parsed = parse_markdown_skill(content);
+        let parsed = skill_discovery::parse_markdown_file(content);
 
         assert_eq!(parsed.prompt, content);
         assert!(parsed.metadata.is_none());
@@ -632,7 +504,7 @@ version: 1.0
 ---
 
 Skill content here."#;
-        let parsed = parse_markdown_skill(content);
+        let parsed = skill_discovery::parse_markdown_file(content);
 
         assert!(parsed.prompt.contains("Skill content"));
         assert!(!parsed.prompt.contains("---"));
@@ -646,7 +518,7 @@ description: YAML Skill
 prompt: This is the prompt content
 version: 1.0.0
 "#;
-        let parsed = parse_yaml_skill(content);
+        let parsed = skill_discovery::parse_yaml_file(content);
 
         assert!(parsed.prompt.contains("prompt content"));
         assert!(parsed.metadata.is_some());

--- a/crates/tools/src/skill_discovery.rs
+++ b/crates/tools/src/skill_discovery.rs
@@ -1,0 +1,282 @@
+//! Shared skill discovery and parsing logic
+//!
+//! This module contains the common path discovery and file parsing functions
+//! used by both `skill.rs` (SkillTool) and `command_skill.rs` (CommandSkillTool).
+//! Eliminates duplication of ~120 LOC between those two modules.
+
+use std::path::{Path, PathBuf};
+
+/// Result of parsing a skill/command file.
+///
+/// Uses `serde_yaml::Value` for metadata so consumers can deserialize
+/// into their own specific metadata types (e.g., `SkillMetadata` or
+/// `CommandSkillMetadata`).
+pub struct ParsedFile {
+    /// The prompt/instruction content (frontmatter stripped for markdown files)
+    pub prompt: String,
+    /// Raw YAML metadata value, if frontmatter was found
+    pub metadata: Option<serde_yaml::Value>,
+}
+
+/// Discover all possible paths where a skill might be located.
+///
+/// Checks project-level (.claude/skills/), user-level (~/.claude/skills/),
+/// plugin-specific, and example plugin directories.
+pub fn discover_skill_paths(skill_name: &str) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    // Support fully-qualified names (e.g., "plugin-name:skill-name")
+    let (plugin, skill) = if skill_name.contains(':') {
+        let parts: Vec<&str> = skill_name.splitn(2, ':').collect();
+        (Some(parts[0]), parts[1])
+    } else {
+        (None, skill_name)
+    };
+
+    // Priority 1: Project-level skills in .claude/skills/
+    paths.push(PathBuf::from(format!(".claude/skills/{}.md", skill)));
+    paths.push(PathBuf::from(format!(".claude/skills/{}/skill.md", skill)));
+    paths.push(PathBuf::from(format!(".claude/skills/{}/SKILL.md", skill)));
+    paths.push(PathBuf::from(format!(".claude/skills/{}.yaml", skill)));
+    paths.push(PathBuf::from(format!(
+        ".claude/skills/{}/skill.yaml",
+        skill
+    )));
+
+    // Priority 2: User-level skills in ~/.claude/skills/
+    if let Some(home) = std::env::var_os("HOME") {
+        let home_path = PathBuf::from(home);
+        paths.push(home_path.join(format!(".claude/skills/{}.md", skill)));
+        paths.push(home_path.join(format!(".claude/skills/{}/skill.md", skill)));
+        paths.push(home_path.join(format!(".claude/skills/{}.yaml", skill)));
+        paths.push(home_path.join(format!(".claude/skills/{}/skill.yaml", skill)));
+    }
+
+    // Priority 3: Plugin-specific skills
+    if let Some(plugin_name) = plugin {
+        paths.push(PathBuf::from(format!(
+            ".claude/plugins/{}/skills/{}.md",
+            plugin_name, skill
+        )));
+        paths.push(PathBuf::from(format!(
+            ".claude/plugins/{}/skills/{}/skill.md",
+            plugin_name, skill
+        )));
+        paths.push(PathBuf::from(format!(
+            ".claude/plugins/{}/skills/{}.yaml",
+            plugin_name, skill
+        )));
+    }
+
+    // Priority 4: Example plugins (for testing/development)
+    paths.push(PathBuf::from(format!(
+        "examples/plugins/example-plugin/skills/{}.md",
+        skill
+    )));
+    paths.push(PathBuf::from(format!(
+        "examples/plugins/example-plugin/skills/{}/skill.md",
+        skill
+    )));
+
+    paths
+}
+
+/// Parse a file and extract prompt and metadata based on file extension.
+///
+/// Dispatches to markdown or YAML parsing as appropriate.
+pub fn parse_file(content: &str, path: &Path) -> ParsedFile {
+    let extension = path.extension().and_then(|s| s.to_str());
+
+    match extension {
+        Some("md") => parse_markdown_file(content),
+        Some("yaml") | Some("yml") => parse_yaml_file(content),
+        _ => ParsedFile {
+            prompt: content.to_string(),
+            metadata: None,
+        },
+    }
+}
+
+/// Parse a markdown file with optional YAML frontmatter.
+///
+/// Strips the `---` delimited frontmatter block and returns the body as
+/// the prompt. The frontmatter YAML is returned as a raw `serde_yaml::Value`.
+pub fn parse_markdown_file(content: &str) -> ParsedFile {
+    if let Some(stripped) = content.strip_prefix("---") {
+        // Has YAML frontmatter
+        if let Some(end_idx) = stripped.find("---") {
+            let frontmatter = &stripped[..end_idx];
+            let prompt = stripped[end_idx + 3..].trim().to_string();
+
+            // Parse frontmatter as raw YAML value
+            let metadata = serde_yaml::from_str::<serde_yaml::Value>(frontmatter).ok();
+
+            return ParsedFile { prompt, metadata };
+        }
+    }
+
+    // No frontmatter, use content as-is
+    ParsedFile {
+        prompt: content.to_string(),
+        metadata: None,
+    }
+}
+
+/// Parse a YAML file, extracting the prompt from known fields.
+///
+/// Looks for `prompt`, `instructions`, or `content` fields for the prompt text.
+/// Returns the full YAML value as metadata.
+pub fn parse_yaml_file(content: &str) -> ParsedFile {
+    if let Ok(yaml_value) = serde_yaml::from_str::<serde_yaml::Value>(content) {
+        // Extract prompt from various possible fields
+        let prompt = if let Some(prompt_val) = yaml_value
+            .get("prompt")
+            .or_else(|| yaml_value.get("instructions"))
+            .or_else(|| yaml_value.get("content"))
+        {
+            prompt_val.as_str().unwrap_or(content).to_string()
+        } else {
+            content.to_string()
+        };
+
+        ParsedFile {
+            prompt,
+            metadata: Some(yaml_value),
+        }
+    } else {
+        // Failed to parse YAML, use as-is
+        ParsedFile {
+            prompt: content.to_string(),
+            metadata: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_discover_skill_paths_basic() {
+        let paths = discover_skill_paths("my-skill");
+
+        assert!(paths
+            .iter()
+            .any(|p| p.to_str().unwrap().contains(".claude/skills/my-skill.md")));
+        assert!(paths.iter().any(|p| p
+            .to_str()
+            .unwrap()
+            .contains(".claude/skills/my-skill/skill.md")));
+        assert!(paths
+            .iter()
+            .any(|p| p.to_str().unwrap().contains(".claude/skills/my-skill.yaml")));
+
+        // Should have multiple paths
+        assert!(paths.len() >= 8);
+    }
+
+    #[test]
+    fn test_discover_skill_paths_with_plugin() {
+        let paths = discover_skill_paths("my-plugin:my-skill");
+        assert!(paths.iter().any(|p| p
+            .to_str()
+            .unwrap()
+            .contains(".claude/plugins/my-plugin/skills/my-skill")));
+    }
+
+    #[test]
+    fn test_parse_markdown_no_frontmatter() {
+        let content = "# Simple Content\n\nJust text.";
+        let parsed = parse_markdown_file(content);
+        assert_eq!(parsed.prompt, content);
+        assert!(parsed.metadata.is_none());
+    }
+
+    #[test]
+    fn test_parse_markdown_with_frontmatter() {
+        let content = r#"---
+description: Test
+version: "1.0"
+---
+
+Skill content here."#;
+        let parsed = parse_markdown_file(content);
+
+        assert!(parsed.prompt.contains("Skill content"));
+        assert!(!parsed.prompt.contains("---"));
+        assert!(parsed.metadata.is_some());
+
+        let meta = parsed.metadata.unwrap();
+        assert_eq!(
+            meta.get("description").and_then(|v| v.as_str()),
+            Some("Test")
+        );
+    }
+
+    #[test]
+    fn test_parse_yaml_file_with_prompt() {
+        let content = r#"
+description: YAML Skill
+prompt: This is the prompt content
+version: 1.0.0
+"#;
+        let parsed = parse_yaml_file(content);
+
+        assert!(parsed.prompt.contains("prompt content"));
+        assert!(parsed.metadata.is_some());
+    }
+
+    #[test]
+    fn test_parse_yaml_file_with_instructions() {
+        let content = r#"
+description: YAML Skill
+instructions: Follow these instructions
+"#;
+        let parsed = parse_yaml_file(content);
+        assert!(parsed.prompt.contains("Follow these instructions"));
+    }
+
+    #[test]
+    fn test_parse_yaml_file_no_known_field() {
+        let content = r#"
+description: YAML Skill
+other_field: something
+"#;
+        let parsed = parse_yaml_file(content);
+        // Falls back to raw content
+        assert_eq!(parsed.prompt, content);
+    }
+
+    #[test]
+    fn test_parse_file_dispatches_by_extension() {
+        let md_path = Path::new("test.md");
+        let yaml_path = Path::new("test.yaml");
+        let yml_path = Path::new("test.yml");
+        let txt_path = Path::new("test.txt");
+
+        let md_content = "---\ndescription: Test\n---\nPrompt here.";
+        let yaml_content = "prompt: YAML prompt";
+
+        let parsed_md = parse_file(md_content, md_path);
+        assert!(parsed_md.prompt.contains("Prompt here"));
+
+        let parsed_yaml = parse_file(yaml_content, yaml_path);
+        assert!(parsed_yaml.prompt.contains("YAML prompt"));
+
+        let parsed_yml = parse_file(yaml_content, yml_path);
+        assert!(parsed_yml.prompt.contains("YAML prompt"));
+
+        let parsed_txt = parse_file("raw text", txt_path);
+        assert_eq!(parsed_txt.prompt, "raw text");
+        assert!(parsed_txt.metadata.is_none());
+    }
+
+    #[test]
+    fn test_discover_skill_paths_includes_uppercase_skill_md() {
+        let paths = discover_skill_paths("my-skill");
+        assert!(paths.iter().any(|p| p
+            .to_str()
+            .unwrap()
+            .contains(".claude/skills/my-skill/SKILL.md")));
+    }
+}


### PR DESCRIPTION
## Summary

- Created `crates/tools/src/skill_discovery.rs` containing shared path discovery and file parsing logic
- Removed ~120 LOC of duplicated code from `skill.rs` and `command_skill.rs`
- Uses `serde_yaml::Value` as the generic metadata return type so each consumer (`SkillMetadata`, `CommandSkillMetadata`) deserializes at the call site
- Public API of `SkillTool`, `CommandSkillTool`, `list_available_skills()`, and `load_skill_content()` remains unchanged

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] `cargo fmt --all` applied (no changes needed)
- [x] `cargo test --all-features` passes (all 3000+ tests)
- [ ] CI pipeline passes

Closes #432

Generated with [Claude Code](https://claude.com/claude-code)