### PR TITLE
fix(ci): remove hardcoded target-dir that breaks GitHub runners

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -26,7 +26,5 @@ codegen-units = 1
 incremental = true
 # Limit parallel jobs to reduce peak disk usage
 jobs = 4
-
-# Shared target directory to prevent worktree disk explosion
-# Each worktree would otherwise create a 2GB+ target directory
-target-dir = "/home/azureuser/src/RustyClawd/target"
+# NOTE: For worktree shared target-dir, set CARGO_TARGET_DIR env var locally
+# instead of hardcoding a path here (breaks CI runners)


### PR DESCRIPTION
## Summary
Remove hardcoded `/home/azureuser/src/RustyClawd/target` from `.cargo/config.toml` that breaks all CI jobs with "Permission denied (os error 13)".

This path was added in dbb5c8c to share target directories across worktrees, but it doesn't exist on GitHub Actions runners.

## Fix
Replace with a comment recommending `CARGO_TARGET_DIR` env var for local use instead.

## Impact
**This unblocks ALL CI checks** for all 12 audit PRs (#441-#456) which are currently failing.

## Test plan
- [x] `cargo check` passes locally
- [ ] CI checks should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)