### PR TITLE
feat: consolidate Claude Code sync tools into /rusty-update skill (#492)

### DIFF
--- a/.claude/commands/rusty-update.md
+++ b/.claude/commands/rusty-update.md
@@ -1,6 +1,6 @@
 ---
 description: Check Claude Code parity, find feature gaps, and sync RustyClawd with upstream changes
-allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebFetch, Agent
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebFetch
 ---
 
 # /rusty-update
@@ -23,9 +23,10 @@ Parse the arguments to determine the mode:
    - `https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md`
    - `https://raw.githubusercontent.com/anthropics/claude-code/main/README.md`
 
-2. Read the local feature inventory at `.claude/data/feature_inventory.yaml`
-
-3. Read the detailed docs inventory at `docs/feature_inventory.yaml` if it exists
+2. Read the local feature inventories:
+   - `docs/feature_inventory.yaml` (primary - most comprehensive and up-to-date)
+   - `.claude/data/feature_inventory.yaml` (used by Rust sync monitor)
+   - If they differ, flag the drift and use the more complete one
 
 4. Compare: For each feature/tool/capability mentioned in the changelog and README, check if it exists in the inventory. Categorize as:
    - **New** - Not in inventory at all
@@ -59,33 +60,37 @@ Parse the arguments to determine the mode:
 
 ## Full Sync Mode
 
-1. Check that `GITHUB_TOKEN` environment variable is set
-2. Run the Rust sync monitor:
+1. Check that `GITHUB_TOKEN` environment variable is set. If not, abort with a clear error.
+2. Read the token value and validate it is non-empty before proceeding.
+3. Run the Rust sync monitor (the binary reads GITHUB_TOKEN from the environment):
    ```bash
-   cargo run --package rustyclawd-tools --example claude_code_sync_cli -- \
+   GITHUB_TOKEN="$GITHUB_TOKEN" cargo run --package rustyclawd-tools --example claude_code_sync_cli -- \
      --inventory .claude/data/feature_inventory.yaml \
      --ledger .claude/data/sync_ledger.json \
-     --token $GITHUB_TOKEN \
      --repo rysweet/RustyClawd
    ```
-3. Report results (features found, gaps identified, issues created)
+   Note: If the binary requires `--token`, pass it, but prefer environment variable.
+4. Report results (features found, gaps identified, issues created)
 
 ## Deep Analysis Mode
 
-1. Run the analysis script:
+1. Check prerequisites: verify `claude`, `prettier`, and `js-beautify` are installed. If missing, tell the user what to install and abort (do NOT auto-install).
+2. Run the analysis script in non-interactive mode:
    ```bash
-   bash scripts/analyze-claude-code.sh
+   echo "n" | bash scripts/analyze-claude-code.sh
    ```
-2. Report the location of deminified files and search indices
-3. Offer to search for specific patterns in the deminified code
+3. Report the location of deminified files and search indices
+4. Offer to search for specific patterns in the deminified code
 
 ## Inventory Update Mode
 
-1. Read current `.claude/data/feature_inventory.yaml`
+1. Read both inventory files:
+   - `docs/feature_inventory.yaml` (primary)
+   - `.claude/data/feature_inventory.yaml` (sync monitor source)
 2. Show current inventory summary (total features, by category, by status)
-3. Ask what features to add or update
-4. Write the updated inventory
-5. Also update `docs/feature_inventory.yaml` if it exists
+3. Flag any drift between the two files
+4. Ask what features to add or update
+5. Write the updated inventory to BOTH files to keep them in sync
 
 ## Communication Style
 

--- a/.claude/skills/rusty-update/SKILL.md
+++ b/.claude/skills/rusty-update/SKILL.md
@@ -42,6 +42,7 @@ dependencies:
   tools:
     - Read
     - Write
+    - Edit
     - Bash
     - Grep
     - Glob
@@ -67,7 +68,7 @@ maturity: production
 maturity_reason: |
   - Rust SyncMonitor module fully implemented with unit tests
   - CI workflow running weekly (.github/workflows/claude-code-sync.yml)
-  - Feature inventory actively maintained with 58+ features tracked
+  - Feature inventory actively maintained (docs/ has 61 features, .claude/data/ has 38 - sync is a known issue)
   - Sync ledger preventing duplicate issue creation
 ---
 
@@ -113,7 +114,7 @@ Deminifies the installed Claude Code cli.js and creates searchable indices.
 /rusty-update analyze
 ```
 
-Requires: `prettier` and `js-beautify` (auto-installed if missing).
+Requires: `prettier` and `js-beautify` (must be installed manually; skill will check and abort with instructions if missing).
 
 ### Inventory Update
 Interactively update the feature inventory after implementing new features.
@@ -133,9 +134,11 @@ Interactively update the feature inventory after implementing new features.
 
 ## Data Files
 
-- **Feature Inventory**: `.claude/data/feature_inventory.yaml` - What RustyClawd implements
+- **Docs Inventory** (primary): `docs/feature_inventory.yaml` - Most comprehensive, with test evidence
+- **Sync Monitor Inventory**: `.claude/data/feature_inventory.yaml` - Used by Rust sync monitor (may lag behind docs version)
 - **Sync Ledger**: `.claude/data/sync_ledger.json` - Issue deduplication tracking
-- **Docs Inventory**: `docs/feature_inventory.yaml` - Detailed docs version with test evidence
+
+**Important**: The `docs/` inventory is the more complete and up-to-date source. The `.claude/data/` version is consumed by the Rust sync monitor. Both should be kept in sync.
 
 ## Architecture
 
@@ -161,8 +164,10 @@ When this skill activates, follow this procedure:
    - `https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md`
    - `https://raw.githubusercontent.com/anthropics/claude-code/main/README.md`
 
-2. **Read** the local feature inventory:
-   - `.claude/data/feature_inventory.yaml`
+2. **Read** both local feature inventories:
+   - `docs/feature_inventory.yaml` (primary, most comprehensive)
+   - `.claude/data/feature_inventory.yaml` (sync monitor source)
+   - Flag any drift between them
 
 3. **Compare** features found in the changelog against the inventory:
    - New features not in inventory = **Missing**
@@ -176,18 +181,26 @@ When this skill activates, follow this procedure:
 
 ### For `sync` mode:
 
-1. Verify `GITHUB_TOKEN` is set
-2. Run: `cargo run --package rustyclawd-tools --example claude_code_sync_cli -- --inventory .claude/data/feature_inventory.yaml --ledger .claude/data/sync_ledger.json --token $GITHUB_TOKEN --repo rysweet/RustyClawd`
+1. Verify `GITHUB_TOKEN` is set in environment. If not, abort with clear error.
+2. Run the Rust sync monitor (pass token via environment, not CLI arg if possible):
+   ```
+   cargo run --package rustyclawd-tools --example claude_code_sync_cli -- \
+     --inventory .claude/data/feature_inventory.yaml \
+     --ledger .claude/data/sync_ledger.json \
+     --token $GITHUB_TOKEN \
+     --repo rysweet/RustyClawd
+   ```
 3. Report created issues
 
 ### For `analyze` mode:
 
-1. Run: `bash scripts/analyze-claude-code.sh`
-2. Report location of deminified files and indices
+1. Check prerequisites: `claude`, `prettier`, `js-beautify` must be installed. Abort with install instructions if missing.
+2. Run: `echo "n" | bash scripts/analyze-claude-code.sh` (pipe "n" to skip interactive VS Code prompt)
+3. Report location of deminified files and indices
 
 ### For `inventory` mode:
 
-1. Read current `.claude/data/feature_inventory.yaml`
-2. Ask what features to add/update
-3. Write updated inventory
-4. Optionally update `docs/feature_inventory.yaml` too
+1. Read both inventory files: `docs/feature_inventory.yaml` (primary) and `.claude/data/feature_inventory.yaml`
+2. Flag any drift between them
+3. Ask what features to add/update
+4. Write updated inventory to BOTH files to keep them in sync


### PR DESCRIPTION
## Summary

- Consolidates 3 separate Claude Code sync/parity tools into one `/rusty-update` skill
- Creates skill definition (`.claude/skills/rusty-update/SKILL.md`) and slash command (`.claude/commands/rusty-update.md`)
- Four modes: `check` (default), `sync`, `analyze`, `inventory`

## What was consolidated

| Previous Tool | New Mode | Status |
|---|---|---|
| `scripts/fetch_claude_features.rs` | `check` | Superseded |
| `crates/tools/examples/claude_code_sync_cli.rs` | `sync` | Wrapped |
| `scripts/analyze-claude-code.sh` | `analyze` | Wrapped |
| (new) | `inventory` | New |

## Test plan

- [ ] Run `/rusty-update` to verify check mode fetches and compares
- [ ] Run `/rusty-update sync` with GITHUB_TOKEN to verify issue creation
- [ ] Run `/rusty-update analyze` to verify deminification
- [ ] Run `/rusty-update inventory` to verify YAML update flow
- [ ] Verify skill auto-discovers on phrases like "claude code parity"

Closes #492

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>