### PR TITLE
fix: add path traversal validation to SlashCommand (#503)

### DIFF
--- a/crates/tools/src/slash_command.rs
+++ b/crates/tools/src/slash_command.rs
@@ -79,6 +79,15 @@ impl crate::Tool for SlashCommandTool {
                 percentage: Some(40.0),
             };
 
+            // Validate command name against path traversal
+            if command_name.contains('/') || command_name.contains('\\') || command_name.contains("..") {
+                tracing::warn!(command_name = %command_name, "Rejected command name containing path traversal characters");
+                yield ToolEvent::Error {
+                    message: format!("Invalid command name: {}", command_name),
+                };
+                return;
+            }
+
             // Look for command file in .claude/commands/
             let command_path = PathBuf::from(format!(".claude/commands/{}.md", command_name));
 


### PR DESCRIPTION
## Summary
Adds path traversal validation to SlashCommand tool, matching the existing pattern in skill.rs:206-216.

## Change
Rejects command names containing `/`, `\`, or `..` before constructing file paths.

## Test plan
- [x] Pattern matches existing validated code in skill.rs
- [x] CI will verify compilation

Closes #503