### PR TITLE
fix: pin tui-textarea to commit hash (#516)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ chrono = { version = "0.4", features = ["serde"] }
 libc = "0.2"
 
 [patch.crates-io]
-tui-textarea = { git = "https://github.com/0xferrous/tui-textarea", branch = "update-ratatui" }
+tui-textarea = { git = "https://github.com/0xferrous/tui-textarea", rev = "a5086767ee0831e319aec9432aaef495d8f280c4" }
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
## Summary

- Pins the `tui-textarea` git fork dependency to specific commit `a5086767ee0831e319aec9432aaef495d8f280c4` instead of tracking the `update-ratatui` branch
- Prevents potential supply chain attacks via force-push to the tracked branch

Closes #516

## Test plan

- [ ] Verify `cargo check` resolves the same dependency
- [ ] Verify `Cargo.lock` remains unchanged (same commit was already resolved)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>