### PR TITLE
test: add grep and glob tool tests (#512, #513)

### DIFF
--- a/crates/tools/src/glob_tool.rs
+++ b/crates/tools/src/glob_tool.rs
@@ -196,4 +196,93 @@ mod tests {
         assert!(result.files.iter().any(|f| f.ends_with("test.rs")));
         assert!(result.files.iter().any(|f| f.ends_with("bar.rs")));
     }
+
+    /// Helper: run glob and extract GlobOutput from the stream.
+    async fn run_glob(params: GlobParams) -> GlobOutput {
+        let tool = GlobTool;
+        let ctx = ToolContext::default();
+        let stream = tool.execute(params, &ctx).await.unwrap();
+        let events: Vec<_> = stream.collect().await;
+        events
+            .into_iter()
+            .find_map(|e| match e {
+                ToolEvent::Result(output) => Some(output),
+                _ => None,
+            })
+            .expect("Expected a Result event from GlobTool")
+    }
+
+    #[tokio::test]
+    async fn test_glob_recursive_pattern() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create nested directory structure
+        let sub = temp_dir.path().join("sub");
+        let subsub = sub.join("deep");
+        std::fs::create_dir_all(&subsub).unwrap();
+
+        std::fs::File::create(temp_dir.path().join("top.rs")).unwrap();
+        std::fs::File::create(sub.join("mid.rs")).unwrap();
+        std::fs::File::create(subsub.join("bottom.rs")).unwrap();
+        std::fs::File::create(subsub.join("other.txt")).unwrap();
+
+        let params = GlobParams {
+            pattern: "**/*.rs".to_string(),
+            path: Some(temp_dir.path().to_str().unwrap().to_string()),
+        };
+
+        let result = run_glob(params).await;
+        assert_eq!(result.count, 3);
+        assert!(result.files.iter().any(|f| f.ends_with("top.rs")));
+        assert!(result.files.iter().any(|f| f.ends_with("mid.rs")));
+        assert!(result.files.iter().any(|f| f.ends_with("bottom.rs")));
+    }
+
+    #[tokio::test]
+    async fn test_glob_no_matches() {
+        let temp_dir = TempDir::new().unwrap();
+        std::fs::File::create(temp_dir.path().join("file.txt")).unwrap();
+
+        let params = GlobParams {
+            pattern: "*.zzz_nonexistent".to_string(),
+            path: Some(temp_dir.path().to_str().unwrap().to_string()),
+        };
+
+        let result = run_glob(params).await;
+        assert_eq!(result.count, 0);
+        assert!(result.files.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_glob_nonexistent_path() {
+        let params = GlobParams {
+            pattern: "*.rs".to_string(),
+            path: Some("/tmp/nonexistent_glob_test_dir_12345".to_string()),
+        };
+
+        let result = run_glob(params).await;
+        assert_eq!(result.count, 0);
+        assert!(result.files.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_glob_with_path_parameter() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let subdir = temp_dir.path().join("mydir");
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::File::create(subdir.join("a.py")).unwrap();
+        std::fs::File::create(subdir.join("b.py")).unwrap();
+        std::fs::File::create(temp_dir.path().join("c.py")).unwrap();
+
+        // Only search inside subdir via path parameter
+        let params = GlobParams {
+            pattern: "*.py".to_string(),
+            path: Some(subdir.to_str().unwrap().to_string()),
+        };
+
+        let result = run_glob(params).await;
+        assert_eq!(result.count, 2);
+        assert!(result.files.iter().all(|f| f.contains("mydir")));
+    }
 }

--- a/crates/tools/src/grep.rs
+++ b/crates/tools/src/grep.rs
@@ -279,4 +279,183 @@ mod tests {
         }
         // else: ripgrep not installed, test skipped
     }
+
+    /// Helper: run grep and extract the GrepOutput from the stream.
+    /// Returns None if ripgrep is not installed (error event instead of result).
+    async fn run_grep(params: GrepParams) -> Option<GrepOutput> {
+        let tool = GrepTool;
+        let ctx = ToolContext::default();
+        let stream = tool.execute(params, &ctx).await.unwrap();
+        let events: Vec<_> = stream.collect().await;
+        events.into_iter().find_map(|e| match e {
+            ToolEvent::Result(output) => Some(output),
+            _ => None,
+        })
+    }
+
+    fn make_params(pattern: &str, path: &str) -> GrepParams {
+        GrepParams {
+            pattern: pattern.to_string(),
+            path: Some(path.to_string()),
+            output_mode: OutputMode::FilesWithMatches,
+            case_insensitive: false,
+            glob: None,
+            before_context: None,
+            after_context: None,
+            head_limit: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_grep_case_insensitive() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut f = std::fs::File::create(temp_dir.path().join("a.txt")).unwrap();
+        writeln!(f, "Hello WORLD").unwrap();
+        writeln!(f, "hello world").unwrap();
+        writeln!(f, "no match here").unwrap();
+
+        let mut params = make_params("hello", temp_dir.path().to_str().unwrap());
+        params.output_mode = OutputMode::Content;
+        params.case_insensitive = true;
+
+        if let Some(result) = run_grep(params).await {
+            // Both "Hello WORLD" and "hello world" should match
+            assert_eq!(result.count, 2);
+            assert!(result.results.iter().any(|r| r.contains("Hello WORLD")));
+            assert!(result.results.iter().any(|r| r.contains("hello world")));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_grep_no_matches() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut f = std::fs::File::create(temp_dir.path().join("a.txt")).unwrap();
+        writeln!(f, "nothing interesting here").unwrap();
+
+        let params = make_params("ZZZZNOTFOUND", temp_dir.path().to_str().unwrap());
+        if let Some(result) = run_grep(params).await {
+            assert_eq!(result.count, 0);
+            assert!(result.results.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_grep_content_mode() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut f = std::fs::File::create(temp_dir.path().join("code.rs")).unwrap();
+        writeln!(f, "fn main() {{}}").unwrap();
+        writeln!(f, "fn helper() {{}}").unwrap();
+        writeln!(f, "let x = 42;").unwrap();
+
+        let mut params = make_params("fn", temp_dir.path().to_str().unwrap());
+        params.output_mode = OutputMode::Content;
+
+        if let Some(result) = run_grep(params).await {
+            assert_eq!(result.count, 2);
+            // Content mode includes line numbers (rg --line-number)
+            assert!(result.results.iter().any(|r| r.contains("fn main")));
+            assert!(result.results.iter().any(|r| r.contains("fn helper")));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_grep_count_mode() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut f = std::fs::File::create(temp_dir.path().join("data.txt")).unwrap();
+        writeln!(f, "apple").unwrap();
+        writeln!(f, "banana").unwrap();
+        writeln!(f, "apple pie").unwrap();
+
+        let mut params = make_params("apple", temp_dir.path().to_str().unwrap());
+        params.output_mode = OutputMode::Count;
+
+        if let Some(result) = run_grep(params).await {
+            // Count mode: rg --count produces "file:N" lines
+            assert_eq!(result.count, 1); // one line of output: "data.txt:2"
+            assert!(result.results[0].contains("2"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_grep_with_context() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut f = std::fs::File::create(temp_dir.path().join("ctx.txt")).unwrap();
+        writeln!(f, "line1").unwrap();
+        writeln!(f, "line2").unwrap();
+        writeln!(f, "MATCH").unwrap();
+        writeln!(f, "line4").unwrap();
+        writeln!(f, "line5").unwrap();
+
+        let mut params = make_params("MATCH", temp_dir.path().to_str().unwrap());
+        params.output_mode = OutputMode::Content;
+        params.before_context = Some(1);
+        params.after_context = Some(1);
+
+        if let Some(result) = run_grep(params).await {
+            // Should include line2 (before), MATCH, line4 (after)
+            let joined = result.results.join("\n");
+            assert!(joined.contains("line2"));
+            assert!(joined.contains("MATCH"));
+            assert!(joined.contains("line4"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_grep_with_head_limit() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut f = std::fs::File::create(temp_dir.path().join("many.txt")).unwrap();
+        for i in 0..50 {
+            writeln!(f, "line {}", i).unwrap();
+        }
+
+        let mut params = make_params("line", temp_dir.path().to_str().unwrap());
+        params.output_mode = OutputMode::Content;
+        params.head_limit = Some(5);
+
+        if let Some(result) = run_grep(params).await {
+            assert_eq!(result.count, 5);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_grep_with_glob_filter() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut rs = std::fs::File::create(temp_dir.path().join("code.rs")).unwrap();
+        writeln!(rs, "fn main() {{}}").unwrap();
+        let mut txt = std::fs::File::create(temp_dir.path().join("notes.txt")).unwrap();
+        writeln!(txt, "fn is a keyword").unwrap();
+
+        let mut params = make_params("fn", temp_dir.path().to_str().unwrap());
+        params.output_mode = OutputMode::FilesWithMatches;
+        params.glob = Some("*.rs".to_string());
+
+        if let Some(result) = run_grep(params).await {
+            assert_eq!(result.count, 1);
+            assert!(result.results[0].contains("code.rs"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_grep_nonexistent_path() {
+        let params = make_params("anything", "/tmp/nonexistent_grep_test_dir_12345");
+        // rg on a nonexistent path produces no results (exit code 2)
+        let tool = GrepTool;
+        let ctx = ToolContext::default();
+        let stream = tool.execute(params, &ctx).await.unwrap();
+        let events: Vec<_> = stream.collect().await;
+
+        // Should get a result with 0 matches or an error event — either is acceptable
+        let has_result = events.iter().any(|e| matches!(e, ToolEvent::Result(_)));
+        let has_error = events.iter().any(|e| matches!(e, ToolEvent::Error { .. }));
+        assert!(
+            has_result || has_error,
+            "Expected either a result or error event for nonexistent path"
+        );
+        if let Some(result) = events.iter().find_map(|e| match e {
+            ToolEvent::Result(o) => Some(o),
+            _ => None,
+        }) {
+            assert_eq!(result.count, 0);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Added 8 comprehensive tests for `grep.rs`: case insensitive, no matches, content mode, count mode, context lines, head limit, glob filter, nonexistent path
- Added 4 comprehensive tests for `glob_tool.rs`: recursive pattern, no matches, nonexistent path, path parameter
- All 12 new tests pass alongside the existing tests

## Test plan

- [x] `cargo test -p rustyclawd-tools --lib grep::tests` -- 9 passed (8 new + 1 existing)
- [x] `cargo test -p rustyclawd-tools --lib glob_tool::tests` -- 5 passed (4 new + 1 existing)

Closes #512
Closes #513

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>