### PR TITLE
feat: add /loop and /copy built-in commands

### DIFF
--- a/crates/cli/src/commands/builtins.rs
+++ b/crates/cli/src/commands/builtins.rs
@@ -5,6 +5,7 @@
 //! text have been removed. When real implementations are ready, add them back.
 
 use crate::commands::parser::Command;
+use crate::scheduled_tasks::parse_interval;
 
 /// Built-in command handler
 pub struct BuiltinCommands;
@@ -28,6 +29,8 @@ impl BuiltinCommands {
                 | "rename"
                 | "debug"
                 | "color"
+                | "loop"
+                | "copy"
         )
     }
 
@@ -47,6 +50,8 @@ impl BuiltinCommands {
             "rename" => Some(Self::rename_command(&cmd.args_str)),
             "debug" => Some(Self::debug_command()),
             "color" => Some(Self::color_command(&cmd.args_str)),
+            "loop" => Some(Self::loop_command(&cmd.args_str)),
+            "copy" => Some(Self::copy_command()),
             _ => None,
         }
     }
@@ -82,6 +87,8 @@ impl BuiltinCommands {
                /add-dir <path>        - Add working directory\n\
                /fast                  - Toggle fast mode\n\
                /color <mode>          - Set color output mode (default, gray, reset, none)\n\
+               /copy                  - Select and copy a code block to clipboard\n\
+               /loop <interval> <prompt> - Run a prompt on a recurring schedule\n\
                /model                 - Show or switch model (handled in session layer)\n\
                /rename [name]         - Rename current session\n\
                /debug                 - Show debug information for troubleshooting\n\n\
@@ -251,6 +258,65 @@ impl BuiltinCommands {
                 VALID_MODES.join(", ")
             ),
         }
+    }
+
+    /// /loop <interval> <prompt> - Schedule a recurring prompt
+    ///
+    /// Parses an interval (e.g. "5m", "1h", "30s") and a prompt string.
+    /// Returns an IPC marker for the session loop to wire up scheduling.
+    fn loop_command(args: &Option<String>) -> String {
+        let args_str = match args {
+            Some(a) if !a.trim().is_empty() => a.trim(),
+            _ => {
+                return "Usage: /loop <interval> <prompt>\n\n\
+                        Interval examples: 30s, 5m, 1h\n\n\
+                        Example:\n  /loop 5m check build status"
+                    .to_string();
+            }
+        };
+
+        // First whitespace-delimited token is the interval, rest is the prompt.
+        let (interval_str, prompt) = match args_str.split_once(char::is_whitespace) {
+            Some((i, p)) if !p.trim().is_empty() => (i, p.trim()),
+            _ => {
+                return "Usage: /loop <interval> <prompt>\n\n\
+                        Both an interval and a prompt are required.\n\n\
+                        Example:\n  /loop 5m check build status"
+                    .to_string();
+            }
+        };
+
+        match parse_interval(interval_str) {
+            Some(duration) => {
+                let secs = duration.as_secs();
+                let human = if secs >= 3600 && secs % 3600 == 0 {
+                    format!("{}h", secs / 3600)
+                } else if secs >= 60 && secs % 60 == 0 {
+                    format!("{}m", secs / 60)
+                } else {
+                    format!("{}s", secs)
+                };
+                format!(
+                    "[[SCHEDULE_LOOP:{}:{}]]\n\n\
+                     Scheduled: will run '{}' every {}",
+                    secs, prompt, prompt, human
+                )
+            }
+            None => {
+                format!(
+                    "Invalid interval: '{}'\n\n\
+                     Accepted formats: 30s, 5m, 1h (positive integer + s/m/h)",
+                    interval_str
+                )
+            }
+        }
+    }
+
+    /// /copy - Select and copy a code block from the conversation to clipboard.
+    ///
+    /// Returns an IPC marker for the TUI layer to present a code-block picker.
+    fn copy_command() -> String {
+        "[[COPY_CODE_BLOCK]]".to_string()
     }
 
     /// /debug - Show debug information for session troubleshooting (v2.1.31)
@@ -689,5 +755,76 @@ mod tests {
 
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "Color set to: default");
+    }
+
+    // ── /loop tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_is_builtin_loop() {
+        assert!(BuiltinCommands::is_builtin("loop"));
+    }
+
+    #[test]
+    fn test_execute_loop_no_args() {
+        let cmd = Command::new("loop".to_string(), None);
+        let result = BuiltinCommands::execute(&cmd).unwrap();
+        assert!(result.contains("Usage"));
+        assert!(result.contains("/loop"));
+    }
+
+    #[test]
+    fn test_execute_loop_interval_only() {
+        let cmd = Command::new("loop".to_string(), Some("5m".to_string()));
+        let result = BuiltinCommands::execute(&cmd).unwrap();
+        assert!(result.contains("Usage"));
+    }
+
+    #[test]
+    fn test_execute_loop_valid() {
+        let cmd = Command::new(
+            "loop".to_string(),
+            Some("5m check build status".to_string()),
+        );
+        let result = BuiltinCommands::execute(&cmd).unwrap();
+        assert!(result.contains("[[SCHEDULE_LOOP:300:check build status]]"));
+        assert!(result.contains("every 5m"));
+    }
+
+    #[test]
+    fn test_execute_loop_seconds() {
+        let cmd = Command::new("loop".to_string(), Some("30s ping".to_string()));
+        let result = BuiltinCommands::execute(&cmd).unwrap();
+        assert!(result.contains("[[SCHEDULE_LOOP:30:ping]]"));
+        assert!(result.contains("every 30s"));
+    }
+
+    #[test]
+    fn test_execute_loop_hours() {
+        let cmd = Command::new("loop".to_string(), Some("1h run report".to_string()));
+        let result = BuiltinCommands::execute(&cmd).unwrap();
+        assert!(result.contains("[[SCHEDULE_LOOP:3600:run report]]"));
+        assert!(result.contains("every 1h"));
+    }
+
+    #[test]
+    fn test_execute_loop_invalid_interval() {
+        let cmd = Command::new("loop".to_string(), Some("abc do stuff".to_string()));
+        let result = BuiltinCommands::execute(&cmd).unwrap();
+        assert!(result.contains("Invalid interval"));
+        assert!(result.contains("abc"));
+    }
+
+    // ── /copy tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_is_builtin_copy() {
+        assert!(BuiltinCommands::is_builtin("copy"));
+    }
+
+    #[test]
+    fn test_execute_copy() {
+        let cmd = Command::new("copy".to_string(), None);
+        let result = BuiltinCommands::execute(&cmd).unwrap();
+        assert_eq!(result, "[[COPY_CODE_BLOCK]]");
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -15,6 +15,7 @@ pub mod mcp_serve;
 pub mod notification;
 pub mod permission_mode;
 pub mod plugins;
+pub mod scheduled_tasks;
 pub mod schema_validator;
 pub mod session;
 pub mod session_graph;

--- a/crates/cli/src/scheduled_tasks.rs
+++ b/crates/cli/src/scheduled_tasks.rs
@@ -1,0 +1,131 @@
+//! Scheduled task support for the /loop command.
+//!
+//! Provides interval parsing and a `ScheduledTask` struct that the session
+//! loop can use to drive recurring prompt execution.
+
+use std::time::{Duration, Instant};
+
+/// A recurring task created by `/loop`.
+#[derive(Debug, Clone)]
+pub struct ScheduledTask {
+    /// How often to run the prompt.
+    pub interval: Duration,
+    /// The prompt text to execute each cycle.
+    pub prompt: String,
+    /// When this task was created.
+    pub created_at: Instant,
+}
+
+/// Parse a human-friendly interval string into a [`Duration`].
+///
+/// Accepted suffixes:
+/// - `s` — seconds (e.g. `30s`)
+/// - `m` — minutes (e.g. `5m`)
+/// - `h` — hours   (e.g. `1h`)
+///
+/// A bare number without a suffix is treated as seconds.
+///
+/// # Errors
+///
+/// Returns `None` when the string is empty, the numeric part is not a valid
+/// positive integer, or the suffix is unrecognised.
+pub fn parse_interval(input: &str) -> Option<Duration> {
+    let input = input.trim();
+    if input.is_empty() {
+        return None;
+    }
+
+    // Split into numeric prefix and optional suffix character.
+    let (num_str, suffix) = if input.ends_with(|c: char| c.is_ascii_alphabetic()) {
+        let boundary = input.len() - 1;
+        (&input[..boundary], Some(&input[boundary..]))
+    } else {
+        (input, None)
+    };
+
+    let value: u64 = num_str.parse().ok().filter(|&v| v > 0)?;
+
+    let secs = match suffix {
+        Some("s") | None => value,
+        Some("m") => value.checked_mul(60)?,
+        Some("h") => value.checked_mul(3600)?,
+        _ => return None,
+    };
+
+    Some(Duration::from_secs(secs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_interval ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_seconds() {
+        assert_eq!(parse_interval("30s"), Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn test_parse_minutes() {
+        assert_eq!(parse_interval("5m"), Some(Duration::from_secs(300)));
+    }
+
+    #[test]
+    fn test_parse_hours() {
+        assert_eq!(parse_interval("1h"), Some(Duration::from_secs(3600)));
+    }
+
+    #[test]
+    fn test_parse_bare_number_defaults_to_seconds() {
+        assert_eq!(parse_interval("45"), Some(Duration::from_secs(45)));
+    }
+
+    #[test]
+    fn test_parse_with_whitespace() {
+        assert_eq!(parse_interval("  10m  "), Some(Duration::from_secs(600)));
+    }
+
+    #[test]
+    fn test_parse_zero_returns_none() {
+        assert_eq!(parse_interval("0s"), None);
+        assert_eq!(parse_interval("0"), None);
+    }
+
+    #[test]
+    fn test_parse_empty_returns_none() {
+        assert_eq!(parse_interval(""), None);
+        assert_eq!(parse_interval("   "), None);
+    }
+
+    #[test]
+    fn test_parse_invalid_suffix() {
+        assert_eq!(parse_interval("5x"), None);
+        assert_eq!(parse_interval("10d"), None);
+    }
+
+    #[test]
+    fn test_parse_non_numeric() {
+        assert_eq!(parse_interval("abc"), None);
+        assert_eq!(parse_interval("m"), None);
+    }
+
+    #[test]
+    fn test_parse_negative() {
+        // u64 parse will reject negative numbers
+        assert_eq!(parse_interval("-5m"), None);
+    }
+
+    // ── ScheduledTask construction ──────────────────────────────────────
+
+    #[test]
+    fn test_scheduled_task_creation() {
+        let task = ScheduledTask {
+            interval: Duration::from_secs(60),
+            prompt: "check status".to_string(),
+            created_at: Instant::now(),
+        };
+        assert_eq!(task.interval, Duration::from_secs(60));
+        assert_eq!(task.prompt, "check status");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `/loop <interval> <prompt>` command that parses human-friendly intervals (30s, 5m, 1h) and emits `[[SCHEDULE_LOOP]]` IPC marker for session-loop integration
- Add `/copy` command that emits `[[COPY_CODE_BLOCK]]` IPC marker for TUI code-block picker
- Add `scheduled_tasks.rs` module with `ScheduledTask` struct and `parse_interval()` function
- 11 new tests for interval parsing, 8 new tests for the two commands (61 total in builtins + scheduled_tasks)

## Test plan
- [x] All 50 builtin tests pass (`cargo test -p rustyclawd-cli -- builtins::tests`)
- [x] All 11 scheduled_tasks tests pass (`cargo test -p rustyclawd-cli -- scheduled_tasks::tests`)
- [ ] Verify `/loop` and `/copy` appear in `/help` output
- [ ] Verify IPC markers are consumed correctly by TUI layer (future integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)