### PR TITLE
fix: redirect tracing to stderr for stream-json SDK compat

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -104,12 +104,24 @@ impl App {
     /// Configure the tracing subscriber based on CLI verbosity.
     fn init_logging(cli: &Cli) {
         let log_level = if cli.verbose { "debug" } else { "info" };
-        tracing_subscriber::fmt()
-            .with_env_filter(log_level)
-            .with_target(false)
-            .with_thread_ids(false)
-            .compact()
-            .init();
+        // When output format is stream-json, logs MUST go to stderr so they don't
+        // pollute the JSON protocol on stdout (required for Claude Agent SDK compat)
+        if cli.output_format == "stream-json" {
+            tracing_subscriber::fmt()
+                .with_env_filter(log_level)
+                .with_target(false)
+                .with_thread_ids(false)
+                .with_writer(std::io::stderr)
+                .compact()
+                .init();
+        } else {
+            tracing_subscriber::fmt()
+                .with_env_filter(log_level)
+                .with_target(false)
+                .with_thread_ids(false)
+                .compact()
+                .init();
+        }
 
         tracing::info!("Initializing RustyClawd CLI...");
     }


### PR DESCRIPTION
Tracing was going to stdout, breaking the JSON protocol. SDK reads stdout as JSON and choked on ANSI log lines. Now uses stderr for stream-json mode.