### PR TITLE
fix: release workflow permissions for version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
   version-bump:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
       sha: ${{ steps.bump.outputs.sha }}
@@ -25,6 +27,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
 
       - name: Bump patch version
         id: bump


### PR DESCRIPTION
## Summary
- Add `contents: write` permission to version-bump job
- Enable `persist-credentials: true` on checkout
- Fixes: release workflow 403 on `git push` when bumping version

🤖 Generated with [Claude Code](https://claude.com/claude-code)