### PR TITLE
fix: drop aarch64-linux cross-compile from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,23 +26,17 @@ jobs:
   build:
     needs: prepare
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            cross: false
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            cross: true
           - os: macos-latest
             target: x86_64-apple-darwin
-            cross: false
           - os: macos-latest
             target: aarch64-apple-darwin
-            cross: false
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            cross: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -55,25 +49,9 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools (aarch64 Linux)
-        if: matrix.cross
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-
       - name: Install OpenSSL (Linux)
-        if: runner.os == 'Linux' && !matrix.cross
+        if: runner.os == 'Linux'
         run: sudo apt-get install -y pkg-config libssl-dev
-
-      - name: Install OpenSSL (cross aarch64)
-        if: matrix.cross
-        run: |
-          sudo dpkg --add-architecture arm64
-          sudo apt-get update
-          sudo apt-get install -y libssl-dev:arm64
-          echo "PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu" >> "$GITHUB_ENV"
-          echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig" >> "$GITHUB_ENV"
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} --bin rusty


### PR DESCRIPTION
## Summary
- Drop aarch64-linux build (cross-compile OpenSSL fails on GH runners)
- Add fail-fast: false so remaining 4 platforms build independently
- Platforms: linux-x86_64, macos-x86_64, macos-aarch64, windows-x86_64

🤖 Generated with [Claude Code](https://claude.com/claude-code)