### PR TITLE
ci: auto-tag releases on merge to main

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,43 @@
+name: Auto Tag on Merge
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get current version
+        id: version
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Current version: $VERSION"
+
+      - name: Check if tag exists
+        id: check
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          if git tag -l "$TAG" | grep -q "$TAG"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG already exists, skipping"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG does not exist, will create"
+          fi
+
+      - name: Create tag
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          git tag -a "$TAG" -m "Auto-release $TAG"
+          git push origin "$TAG"
+          echo "Created and pushed tag: $TAG"


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that creates a version tag from `Cargo.toml` whenever code is merged to `main`
- Only creates the tag if it doesn't already exist (idempotent)
- Triggers the existing `release.yml` workflow to build and publish binaries

## Details

The workflow reads the `version` field from the root `Cargo.toml`, checks if a `v{version}` tag already exists, and creates an annotated tag if not. This automates the release tagging that was previously a manual step.

## Test plan

- [ ] Merge a PR to main and verify the tag is created
- [ ] Verify `release.yml` triggers on the new tag
- [ ] Merge again without bumping version — tag should be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)