### PR TITLE
fix: merge all choices in Copilot response to capture tool calls

### DIFF
--- a/crates/core/src/client/copilot.rs
+++ b/crates/core/src/client/copilot.rs
@@ -606,18 +606,26 @@ pub(crate) fn to_oai_request(request: &CreateMessageRequest) -> OaiChatRequest {
 
 /// Convert an OpenAI chat response back to our internal MessageResponse.
 pub fn from_oai_response(oai: OaiChatResponse) -> MessageResponse {
-    let choice = oai.choices.into_iter().next();
-
     let mut content = Vec::new();
     let mut stop_reason = None;
 
-    if let Some(choice) = choice {
-        stop_reason = choice.finish_reason.map(|r| match r.as_str() {
-            "stop" => "end_turn".to_string(),
-            "tool_calls" => "tool_use".to_string(),
-            "length" => "max_tokens".to_string(),
-            other => other.to_string(),
-        });
+    // Merge ALL choices — the Copilot API may return tool calls as separate
+    // choices rather than as tool_calls within a single message.
+    // choice[0] typically has text content, choice[1..] have tool_calls.
+    for choice in oai.choices {
+        // Use the most specific stop_reason (prefer tool_use over end_turn)
+        if let Some(ref reason) = choice.finish_reason {
+            let mapped = match reason.as_str() {
+                "stop" => "end_turn".to_string(),
+                "tool_calls" => "tool_use".to_string(),
+                "length" => "max_tokens".to_string(),
+                other => other.to_string(),
+            };
+            // tool_use takes priority over end_turn
+            if stop_reason.is_none() || mapped == "tool_use" {
+                stop_reason = Some(mapped);
+            }
+        }
 
         // Add text content if present
         if let Some(text) = choice.message.content {


### PR DESCRIPTION
## Problem
The Copilot API returns tool calls as separate choices:
```json
{"choices": [
  {"finish_reason": "tool_calls", "message": {"content": "I'll analyze..."}},
  {"finish_reason": "tool_calls", "message": {"tool_calls": [{...}]}},
  {"finish_reason": "tool_calls", "message": {"tool_calls": [{...}]}}
]}
```

`from_oai_response` only took `choices[0]` (text) and discarded `choices[1..]` (tool calls). This caused tool calling to silently fail — `stop_reason` was `tool_use` but no `ToolUse` blocks were present, so the tool loop returned immediately.

## Fix
Iterate over ALL choices and merge their content blocks. `tool_use` stop_reason takes priority.

## Impact
This enables **all tool calling** through the Copilot API. Without this fix, agents could never call tools — they always produced text-only responses.