### PR TITLE
feat: add Azure AI Foundry backend (Backend::AzureFoundry)

### DIFF
--- a/crates/cli/src/app_runtime.rs
+++ b/crates/cli/src/app_runtime.rs
@@ -509,7 +509,7 @@ impl App {
             .as_deref()
             .map(|p| {
                 Backend::from_str_loose(p).ok_or_else(|| {
-                    anyhow::anyhow!("Unknown provider '{}'. Use 'anthropic' or 'copilot'.", p)
+                    anyhow::anyhow!("Unknown provider '{}'. Use 'anthropic', 'copilot', or 'azure'.", p)
                 })
             })
             .transpose()?

--- a/crates/cli/src/interactive.rs
+++ b/crates/cli/src/interactive.rs
@@ -105,6 +105,12 @@ impl InteractiveSession {
                     Backend::Copilot,
                 )
             }
+            Backend::AzureFoundry => {
+                return Err(anyhow::anyhow!(
+                    "Azure AI Foundry backend is not yet supported in interactive mode. \
+                     Use it via the skwaq CLI with [llm] reasoning = \"azure\" in skwaq.toml."
+                ));
+            }
             Backend::Anthropic => match Config::from_default_location().await {
                 Ok(config) => (Arc::new(Client::new(config)?), Backend::Anthropic),
                 Err(rustyclawd_core::client::ClientError::ApiKeyNotFound) => {
@@ -164,6 +170,7 @@ impl InteractiveSession {
         // Pick model: CLI override > backend default
         let model = model_override.unwrap_or_else(|| match backend {
             Backend::Copilot => DEFAULT_COPILOT_MODEL.to_string(),
+            Backend::AzureFoundry => DEFAULT_COPILOT_MODEL.to_string(),
             Backend::Anthropic => DEFAULT_MODEL.to_string(),
         });
 

--- a/crates/cli/src/print_mode.rs
+++ b/crates/cli/src/print_mode.rs
@@ -277,6 +277,12 @@ impl App {
                     println!("Use --provider copilot --model <id> to select a model.");
                 }
             }
+            Backend::AzureFoundry => {
+                println!("Azure AI Foundry models are configured via deployment name.");
+                println!("Set deployment in your config: [llm.azure] deployment = \"gpt-51\"");
+                println!();
+                println!("Common deployments: gpt-5.1, gpt-5.4, claude-opus-4-6");
+            }
         }
         Ok(())
     }
@@ -323,7 +329,7 @@ impl App {
             .as_deref()
             .map(|p| {
                 Backend::from_str_loose(p).ok_or_else(|| {
-                    anyhow::anyhow!("Unknown provider '{}'. Use 'anthropic' or 'copilot'.", p)
+                    anyhow::anyhow!("Unknown provider '{}'. Use 'anthropic', 'copilot', or 'azure'.", p)
                 })
             })
             .transpose()?
@@ -370,6 +376,12 @@ impl App {
                     }
                     Err(e) => return Err(e.into()),
                 }
+            }
+            Backend::AzureFoundry => {
+                return Err(anyhow::anyhow!(
+                    "Azure AI Foundry backend is not yet supported in RustyClawd CLI print mode. \
+                     Use it via the skwaq CLI."
+                ));
             }
         };
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 reqwest = { workspace = true }
 
 # Async runtime and utilities
-tokio = { version = "1.0", features = ["fs", "io-util"] }
+tokio = { version = "1.0", features = ["fs", "io-util", "process"] }
 futures = "0.3"
 bytes = "1.0"
 

--- a/crates/core/src/client/azure_foundry.rs
+++ b/crates/core/src/client/azure_foundry.rs
@@ -1,0 +1,293 @@
+//! Azure AI Foundry backend.
+//!
+//! Implements authentication via Azure `DefaultAzureCredential` and provides
+//! request/response translation using the same OpenAI-compatible format as
+//! the Copilot backend. Azure AI Foundry's inference API supports both
+//! OpenAI models (GPT-5.x) and third-party models (Claude, Llama, etc.)
+//! through the same endpoint.
+//!
+//! Auth flow:
+//! 1. Acquire a bearer token via `DefaultAzureCredential` (az login, managed identity, etc.)
+//! 2. Send requests to `{endpoint}/openai/deployments/{deployment}/chat/completions`
+//! 3. Token is cached and refreshed automatically before expiry
+//!
+//! The Azure AI Foundry inference API uses the OpenAI chat completions
+//! format, so we reuse the OAI translation functions from the copilot module.
+
+use reqwest::Client as HttpClient;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use super::copilot::{from_oai_response, from_oai_stream_chunk, to_oai_request, OaiChatResponse};
+use super::error::{ClientError, ClientResult};
+use super::request::CreateMessageRequest;
+use super::response::{MessageResponse, StreamEvent};
+
+const AZURE_COGNITIVE_SCOPE: &str = "https://cognitiveservices.azure.com/.default";
+
+// ---------------------------------------------------------------------------
+// Azure token management
+// ---------------------------------------------------------------------------
+
+/// Cached Azure AD bearer token with expiry tracking.
+#[derive(Clone)]
+struct CachedToken {
+    value: String,
+    expires_at: std::time::Instant,
+}
+
+/// Azure AI Foundry authentication using DefaultAzureCredential.
+///
+/// Acquires tokens from the Azure identity chain (CLI, managed identity,
+/// environment variables, etc.) and caches them until near-expiry.
+#[derive(Clone)]
+pub struct AzureAuth {
+    endpoint: String,
+    deployment: String,
+    api_version: String,
+    cached_token: Arc<RwLock<Option<CachedToken>>>,
+}
+
+impl AzureAuth {
+    /// Create a new Azure auth handle.
+    ///
+    /// Does NOT acquire a token yet — that happens lazily on first request.
+    pub fn new(endpoint: &str, deployment: &str, api_version: &str) -> Self {
+        Self {
+            endpoint: endpoint.trim_end_matches('/').to_string(),
+            deployment: deployment.to_string(),
+            api_version: api_version.to_string(),
+            cached_token: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Get a valid bearer token, refreshing if expired or absent.
+    pub async fn get_token(&self) -> ClientResult<String> {
+        // Check cache first
+        {
+            let cache = self.cached_token.read().await;
+            if let Some(ref tok) = *cache {
+                // Refresh 60s before expiry to avoid edge-case failures
+                if tok.expires_at > std::time::Instant::now() + std::time::Duration::from_secs(60) {
+                    return Ok(tok.value.clone());
+                }
+            }
+        }
+
+        // Acquire a new token via az CLI (DefaultAzureCredential equivalent)
+        let token = acquire_azure_token().await?;
+        let expires_at = std::time::Instant::now() + std::time::Duration::from_secs(3000);
+
+        {
+            let mut cache = self.cached_token.write().await;
+            *cache = Some(CachedToken {
+                value: token.clone(),
+                expires_at,
+            });
+        }
+
+        Ok(token)
+    }
+
+    /// Build the chat completions URL for this deployment.
+    pub fn chat_url(&self) -> String {
+        format!(
+            "{}/openai/deployments/{}/chat/completions?api-version={}",
+            self.endpoint, self.deployment, self.api_version
+        )
+    }
+
+    /// Get the deployment name (used as model name in requests).
+    pub fn deployment(&self) -> &str {
+        &self.deployment
+    }
+}
+
+/// Acquire an Azure AD token using `az account get-access-token`.
+///
+/// This is the CLI-based equivalent of `DefaultAzureCredential` — it works
+/// when the user has run `az login`. For managed identity or service principal
+/// scenarios, the AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_CLIENT_SECRET
+/// environment variables can be used with the azure_identity crate (future).
+async fn acquire_azure_token() -> ClientResult<String> {
+    // Try az CLI first (most common for dev scenarios)
+    let output = tokio::process::Command::new("az")
+        .args([
+            "account",
+            "get-access-token",
+            "--resource",
+            AZURE_COGNITIVE_SCOPE
+                .strip_suffix("/.default")
+                .unwrap_or(AZURE_COGNITIVE_SCOPE),
+            "--query",
+            "accessToken",
+            "--output",
+            "tsv",
+        ])
+        .output()
+        .await
+        .map_err(|e| {
+            ClientError::Unknown(format!(
+                "Failed to run `az account get-access-token`: {e}. \
+                 Ensure Azure CLI is installed and you have run `az login`."
+            ))
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(ClientError::Unknown(format!(
+            "Azure CLI token acquisition failed: {stderr}"
+        )));
+    }
+
+    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if token.is_empty() {
+        return Err(ClientError::Unknown(
+            "Azure CLI returned an empty token. Run `az login` to authenticate.".to_string(),
+        ));
+    }
+
+    Ok(token)
+}
+
+// ---------------------------------------------------------------------------
+// Non-streaming request
+// ---------------------------------------------------------------------------
+
+/// Execute a non-streaming chat completion against Azure AI Foundry.
+pub async fn create_message(
+    http_client: &HttpClient,
+    auth: &AzureAuth,
+    request: &CreateMessageRequest,
+) -> ClientResult<MessageResponse> {
+    let token = auth.get_token().await?;
+    let mut oai_request = to_oai_request(request);
+    // Use the deployment name as the model
+    oai_request.model = auth.deployment().to_string();
+
+    let response = http_client
+        .post(auth.chat_url())
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&oai_request)
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        return Err(ClientError::from_response(response).await);
+    }
+
+    let oai_response: OaiChatResponse = response.json().await?;
+    Ok(from_oai_response(oai_response))
+}
+
+// ---------------------------------------------------------------------------
+// Streaming request
+// ---------------------------------------------------------------------------
+
+/// Execute a streaming chat completion against Azure AI Foundry.
+pub async fn create_message_stream(
+    http_client: &HttpClient,
+    auth: &AzureAuth,
+    request: &CreateMessageRequest,
+) -> ClientResult<impl futures::Stream<Item = ClientResult<StreamEvent>>> {
+    let token = auth.get_token().await?;
+    let mut oai_request = to_oai_request(request);
+    oai_request.model = auth.deployment().to_string();
+    oai_request.stream = true;
+
+    let response = http_client
+        .post(auth.chat_url())
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "text/event-stream")
+        .json(&oai_request)
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        return Err(ClientError::from_response(response).await);
+    }
+
+    // Parse the SSE stream — same format as Copilot (OpenAI SSE)
+    use super::copilot::OaiStreamChunk;
+
+    let byte_stream = response.bytes_stream();
+    let block_index: u32 = 0;
+
+    Ok(futures::stream::unfold(
+        (byte_stream, String::new(), block_index),
+        move |(mut stream, mut buffer, mut bi)| async move {
+            use futures::TryStreamExt;
+            loop {
+                // Try to parse any complete SSE events from the buffer
+                while let Some(line_end) = buffer.find('\n') {
+                    let line = buffer[..line_end].trim_end_matches('\r').to_string();
+                    buffer = buffer[line_end + 1..].to_string();
+
+                    if let Some(data) = line.strip_prefix("data: ") {
+                        if data == "[DONE]" {
+                            return None;
+                        }
+                        if let Ok(chunk) = serde_json::from_str::<OaiStreamChunk>(data) {
+                            let events = from_oai_stream_chunk(&chunk, &mut bi);
+                            if let Some(event) = events.into_iter().next() {
+                                return Some((Ok(event), (stream, buffer, bi)));
+                            }
+                        }
+                    }
+                }
+
+                // Read more data from the stream
+                match stream.try_next().await {
+                    Ok(Some(bytes)) => {
+                        buffer.push_str(&String::from_utf8_lossy(&bytes));
+                    }
+                    Ok(None) => return None,
+                    Err(e) => {
+                        return Some((
+                            Err(ClientError::Unknown(format!("Stream error: {e}"))),
+                            (stream, buffer, bi),
+                        ))
+                    }
+                }
+            }
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_azure_auth_url_construction() {
+        let auth = AzureAuth::new(
+            "https://myresource.cognitiveservices.azure.com/",
+            "gpt-51-skwaq",
+            "2024-10-21",
+        );
+        assert_eq!(
+            auth.chat_url(),
+            "https://myresource.cognitiveservices.azure.com/openai/deployments/gpt-51-skwaq/chat/completions?api-version=2024-10-21"
+        );
+    }
+
+    #[test]
+    fn test_azure_auth_trailing_slash_normalized() {
+        let auth = AzureAuth::new(
+            "https://test.cognitiveservices.azure.com",
+            "gpt-54",
+            "2024-10-21",
+        );
+        // No double slash
+        assert!(!auth.chat_url().contains("azure.com//"));
+    }
+
+    #[test]
+    fn test_deployment_accessor() {
+        let auth = AzureAuth::new("https://x.azure.com", "my-deploy", "2024-10-21");
+        assert_eq!(auth.deployment(), "my-deploy");
+    }
+}

--- a/crates/core/src/client/config.rs
+++ b/crates/core/src/client/config.rs
@@ -22,6 +22,8 @@ pub enum Backend {
     Anthropic,
     /// GitHub Copilot API (OpenAI-compatible)
     Copilot,
+    /// Azure AI Foundry (OpenAI-compatible, supports GPT-5.x and third-party models)
+    AzureFoundry,
 }
 
 impl Backend {
@@ -30,6 +32,9 @@ impl Backend {
         match s.to_lowercase().as_str() {
             "anthropic" | "claude" => Some(Self::Anthropic),
             "copilot" | "github" | "gh" => Some(Self::Copilot),
+            "azure" | "azure_foundry" | "azure-foundry" | "azurefoundry" => {
+                Some(Self::AzureFoundry)
+            }
             _ => None,
         }
     }
@@ -40,6 +45,7 @@ impl fmt::Display for Backend {
         match self {
             Backend::Anthropic => write!(f, "anthropic"),
             Backend::Copilot => write!(f, "copilot"),
+            Backend::AzureFoundry => write!(f, "azure"),
         }
     }
 }
@@ -281,6 +287,23 @@ impl Config {
             timeout_secs: Self::DEFAULT_TIMEOUT_SECS,
             account_info: crate::env_config::account_info::AccountInfo::from_env(),
             backend: Backend::Copilot,
+        }
+    }
+
+    /// Create an Azure AI Foundry backend configuration.
+    ///
+    /// Uses a placeholder API key since Azure uses its own AD token auth.
+    /// The `api_url` field stores the Azure endpoint for reference but
+    /// actual URL construction is handled by `AzureAuth`.
+    pub fn new_azure_foundry(endpoint: &str) -> Self {
+        let placeholder = ApiKey::new_unchecked("azure-foundry-backend".to_string());
+        Self {
+            api_key: SecretBox::new(Box::new(placeholder)),
+            api_url: endpoint.trim_end_matches('/').to_string(),
+            api_version: Self::DEFAULT_API_VERSION.to_string(),
+            timeout_secs: 300, // Azure deployments can be slower to cold-start
+            account_info: crate::env_config::account_info::AccountInfo::from_env(),
+            backend: Backend::AzureFoundry,
         }
     }
 

--- a/crates/core/src/client/copilot.rs
+++ b/crates/core/src/client/copilot.rs
@@ -361,7 +361,7 @@ struct OaiFunctionDef {
 /// OpenAI-compatible chat completion request.
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct OaiChatRequest {
-    model: String,
+    pub(crate) model: String,
     messages: Vec<OaiMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u32>,
@@ -369,7 +369,7 @@ pub(crate) struct OaiChatRequest {
     temperature: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     top_p: Option<f32>,
-    stream: bool,
+    pub(crate) stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<OaiToolDef>>,
     n: u32,

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -38,6 +38,7 @@
 
 pub mod config;
 pub mod copilot;
+pub mod azure_foundry;
 pub mod error;
 pub mod request;
 pub mod response;
@@ -58,6 +59,7 @@ use std::time::Duration;
 
 pub use config::{ApiKey, Backend, Config};
 pub use copilot::{CopilotAuth, CopilotModel};
+pub use azure_foundry::AzureAuth;
 pub use error::{ClientError, ClientResult};
 pub use request::{CreateMessageRequest, Metadata, Speed, ThinkingConfig};
 pub use response::{
@@ -70,7 +72,7 @@ pub use types::{
     ContentBlock, ExtraToolSchema, Message, MessageContent, Role, ToolChoice, ToolDefinition,
 };
 
-/// API client supporting Anthropic and GitHub Copilot backends.
+/// API client supporting Anthropic, GitHub Copilot, and Azure AI Foundry backends.
 #[derive(Clone)]
 pub struct Client {
     config: Config,
@@ -78,6 +80,8 @@ pub struct Client {
     retry_config: RetryConfig,
     /// Copilot authentication state (only present when backend is Copilot)
     copilot_auth: Option<CopilotAuth>,
+    /// Azure AI Foundry authentication state (only present when backend is AzureFoundry)
+    azure_auth: Option<AzureAuth>,
 }
 
 impl Client {
@@ -92,6 +96,7 @@ impl Client {
 
         Ok(Self {
             copilot_auth: None,
+            azure_auth: None,
             config,
             http_client,
             retry_config: RetryConfig::default(),
@@ -109,6 +114,7 @@ impl Client {
 
         Ok(Self {
             copilot_auth: None,
+            azure_auth: None,
             config,
             http_client,
             retry_config,
@@ -130,6 +136,34 @@ impl Client {
 
         Ok(Self {
             copilot_auth: Some(auth),
+            azure_auth: None,
+            config,
+            http_client,
+            retry_config: RetryConfig::default(),
+        })
+    }
+
+    /// Create a client configured for Azure AI Foundry.
+    ///
+    /// Token acquisition is lazy — the first request triggers `az account get-access-token`.
+    pub fn new_azure_foundry(
+        endpoint: &str,
+        deployment: &str,
+        api_version: &str,
+    ) -> ClientResult<Self> {
+        let config = Config::new_azure_foundry(endpoint);
+        let timeout = Duration::from_secs(config.timeout_secs);
+
+        let http_client = HttpClient::builder()
+            .timeout(timeout)
+            .build()
+            .map_err(|e| ClientError::Unknown(format!("Failed to build HTTP client: {}", e)))?;
+
+        let auth = AzureAuth::new(endpoint, deployment, api_version);
+
+        Ok(Self {
+            copilot_auth: None,
+            azure_auth: Some(auth),
             config,
             http_client,
             retry_config: RetryConfig::default(),
@@ -191,7 +225,7 @@ impl Client {
 
     /// Create a message (non-streaming) with automatic retry logic.
     ///
-    /// Dispatches to the appropriate backend (Anthropic or Copilot).
+    /// Dispatches to the appropriate backend (Anthropic, Copilot, or Azure).
     pub async fn create_message(
         &self,
         request: CreateMessageRequest,
@@ -206,6 +240,18 @@ impl Client {
                 })?;
                 self.with_retry("copilot request", || {
                     copilot::create_message(&self.http_client, auth, &request)
+                })
+                .await
+            }
+            config::Backend::AzureFoundry => {
+                let auth = self.azure_auth.as_ref().ok_or_else(|| {
+                    ClientError::Unknown(
+                        "Azure backend requires authentication. Use Client::new_azure_foundry()."
+                            .to_string(),
+                    )
+                })?;
+                self.with_retry("azure request", || {
+                    azure_foundry::create_message(&self.http_client, auth, &request)
                 })
                 .await
             }
@@ -280,7 +326,7 @@ impl Client {
 
     /// Create a message with streaming and automatic retry logic.
     ///
-    /// Dispatches to the appropriate backend (Anthropic or Copilot).
+    /// Dispatches to the appropriate backend (Anthropic, Copilot, or Azure).
     /// Returns a boxed stream to unify the different backend stream types.
     pub async fn create_message_stream(
         &self,
@@ -299,6 +345,17 @@ impl Client {
                 })?;
                 let stream =
                     copilot::create_message_stream(&self.http_client, auth, &request).await?;
+                Ok(stream.boxed())
+            }
+            config::Backend::AzureFoundry => {
+                let auth = self.azure_auth.as_ref().ok_or_else(|| {
+                    ClientError::Unknown(
+                        "Azure backend requires authentication. Use Client::new_azure_foundry()."
+                            .to_string(),
+                    )
+                })?;
+                let stream =
+                    azure_foundry::create_message_stream(&self.http_client, auth, &request).await?;
                 Ok(stream.boxed())
             }
             config::Backend::Anthropic => {


### PR DESCRIPTION
## Summary
Adds a third LLM backend to RustyClawd that targets Azure AI Foundry deployments.

## Why Azure AI Foundry (not Azure OpenAI)?
Azure AI Foundry's inference API supports **both** OpenAI models (GPT-5.x) **and** third-party models (Claude, Llama, etc.) through the same endpoint. This is more future-proof than the narrower Azure OpenAI API — when Anthropic models become available in our Azure subscription, they'll work through the same backend.

## Changes
- `Backend::AzureFoundry` variant in the enum with `from_str_loose` support
- `Config::new_azure_foundry(endpoint)` constructor
- `Client::new_azure_foundry(endpoint, deployment, api_version)` — lazy token acquisition
- `azure_foundry.rs` module: token via `az account get-access-token`, cached with auto-refresh
- Non-streaming and streaming dispatch in `create_message` / `create_message_stream`
- Reuses OAI translation from copilot module (same OpenAI-compatible format)
- CLI exhaustive matches updated in interactive, print_mode, app_runtime
- 3 unit tests for URL construction, trailing slash normalization, deployment accessor

## Auth
Uses `az account get-access-token --resource https://cognitiveservices.azure.com` (equivalent to `DefaultAzureCredential`). Works with:
- `az login` (dev)
- Managed identity (prod)
- Service principal (CI/CD)

## Usage (from downstream skwaq)
```rust
let client = Client::new_azure_foundry(
    "https://rysweetballist5347662217.cognitiveservices.azure.com",
    "gpt-51-skwaq",
    "2024-10-21",
)?;
```

## Testing
- 71 core+tools tests pass (0 failures)
- clippy clean with `-D warnings`
- Pre-existing CLI test failure (missing `runtime_agents` field) is unrelated