### PR TITLE
feat: wire Azure AI Foundry backend through CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "1.35", features = ["full"] }
 tokio-util = "0.7"
 
 # CLI
-clap = { version = "4.4", features = ["derive", "cargo"] }
+clap = { version = "4.4", features = ["derive", "cargo", "env"] }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/cli/src/app_runtime.rs
+++ b/crates/cli/src/app_runtime.rs
@@ -203,15 +203,24 @@ impl App {
             .with_context(|| format!("Failed to read prompt file: {}", prompt_file))?;
 
         // Create tool context
-        let runtime_agents_info: std::collections::HashMap<String, rustyclawd_tools::RuntimeAgentInfo> =
-            self.runtime_agents.iter().map(|(name, def)| {
-                (name.clone(), rustyclawd_tools::RuntimeAgentInfo {
-                    prompt: def.prompt.clone(),
-                    model: def.model.clone(),
-                    allowed_tools: def.allowed_tools.clone(),
-                    disallowed_tools: def.disallowed_tools.clone(),
-                })
-            }).collect();
+        let runtime_agents_info: std::collections::HashMap<
+            String,
+            rustyclawd_tools::RuntimeAgentInfo,
+        > = self
+            .runtime_agents
+            .iter()
+            .map(|(name, def)| {
+                (
+                    name.clone(),
+                    rustyclawd_tools::RuntimeAgentInfo {
+                        prompt: def.prompt.clone(),
+                        model: def.model.clone(),
+                        allowed_tools: def.allowed_tools.clone(),
+                        disallowed_tools: def.disallowed_tools.clone(),
+                    },
+                )
+            })
+            .collect();
         let ctx = ToolContext {
             cwd: std::env::current_dir().unwrap_or_default(),
             debug: self.cli.verbose,
@@ -509,11 +518,40 @@ impl App {
             .as_deref()
             .map(|p| {
                 Backend::from_str_loose(p).ok_or_else(|| {
-                    anyhow::anyhow!("Unknown provider '{}'. Use 'anthropic', 'copilot', or 'azure'.", p)
+                    anyhow::anyhow!(
+                        "Unknown provider '{}'. Use 'anthropic', 'copilot', or 'azure'.",
+                        p
+                    )
                 })
             })
             .transpose()?
             .unwrap_or(Backend::Anthropic);
+
+        let azure_config = if backend == Backend::AzureFoundry {
+            Some(interactive::AzureConfig {
+                endpoint: self
+                    .cli
+                    .azure_endpoint
+                    .clone()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Azure AI Foundry requires --azure-endpoint (or AZURE_FOUNDRY_ENDPOINT env var)"
+                        )
+                    })?,
+                deployment: self
+                    .cli
+                    .azure_deployment
+                    .clone()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Azure AI Foundry requires --azure-deployment (or AZURE_OPENAI_DEPLOYMENT env var)"
+                        )
+                    })?,
+                api_version: self.cli.azure_api_version.clone(),
+            })
+        } else {
+            None
+        };
 
         interactive::run_interactive_with_config(
             Some(hooks),
@@ -521,6 +559,7 @@ impl App {
             disallowed_tools,
             backend,
             self.cli.model.clone(),
+            azure_config,
         )
         .await
     }

--- a/crates/cli/src/cli_args.rs
+++ b/crates/cli/src/cli_args.rs
@@ -36,13 +36,25 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) model: Option<String>,
 
-    /// API provider: "anthropic" (default) or "copilot" (GitHub Copilot)
+    /// API provider: "anthropic" (default), "copilot" (GitHub Copilot), or "azure" (Azure AI Foundry)
     #[arg(long, value_name = "PROVIDER")]
     pub(crate) provider: Option<String>,
 
     /// List available models for the selected provider and exit
     #[arg(long)]
     pub(crate) list_models: bool,
+
+    /// Azure AI Foundry endpoint URL (e.g., "https://myresource.openai.azure.com")
+    #[arg(long, value_name = "URL", env = "AZURE_FOUNDRY_ENDPOINT")]
+    pub(crate) azure_endpoint: Option<String>,
+
+    /// Azure AI Foundry deployment name(s), comma-separated for round-robin
+    #[arg(long, value_name = "NAME", env = "AZURE_OPENAI_DEPLOYMENT")]
+    pub(crate) azure_deployment: Option<String>,
+
+    /// Azure OpenAI API version (default: "2024-10-21")
+    #[arg(long, value_name = "VERSION", default_value = "2024-10-21")]
+    pub(crate) azure_api_version: String,
 
     /// Replace entire system prompt with custom text
     #[arg(long)]

--- a/crates/cli/src/interactive.rs
+++ b/crates/cli/src/interactive.rs
@@ -26,6 +26,14 @@ use std::io::{self, Write};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+/// Azure AI Foundry configuration for interactive/print modes.
+#[derive(Clone, Debug)]
+pub struct AzureConfig {
+    pub endpoint: String,
+    pub deployment: String,
+    pub api_version: String,
+}
+
 /// Default model for interactive sessions (Anthropic backend)
 pub(crate) const DEFAULT_MODEL: &str = "claude-opus-4-6";
 
@@ -82,7 +90,7 @@ impl InteractiveSession {
 
     /// Create a new interactive session with optional hooks system
     pub async fn with_hooks(hooks: Option<Arc<hooks::HooksSystem>>) -> Result<Self> {
-        Self::with_hooks_and_backend(hooks, Backend::Anthropic, None).await
+        Self::with_hooks_and_backend(hooks, Backend::Anthropic, None, None).await
     }
 
     /// Create a new interactive session with optional hooks system, backend, and model.
@@ -90,6 +98,7 @@ impl InteractiveSession {
         hooks: Option<Arc<hooks::HooksSystem>>,
         backend: Backend,
         model_override: Option<String>,
+        azure_config: Option<AzureConfig>,
     ) -> Result<Self> {
         // Set execution context to TUI mode for process isolation
         terminal_guard::set_execution_context(terminal_guard::ExecutionContext::Tui);
@@ -106,10 +115,19 @@ impl InteractiveSession {
                 )
             }
             Backend::AzureFoundry => {
-                return Err(anyhow::anyhow!(
-                    "Azure AI Foundry backend is not yet supported in interactive mode. \
-                     Use it via the skwaq CLI with [llm] reasoning = \"azure\" in skwaq.toml."
-                ));
+                let cfg = azure_config.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Azure AI Foundry requires --azure-endpoint and --azure-deployment"
+                    )
+                })?;
+                (
+                    Arc::new(Client::new_azure_foundry(
+                        &cfg.endpoint,
+                        &cfg.deployment,
+                        &cfg.api_version,
+                    )?),
+                    Backend::AzureFoundry,
+                )
             }
             Backend::Anthropic => match Config::from_default_location().await {
                 Ok(config) => (Arc::new(Client::new(config)?), Backend::Anthropic),
@@ -692,7 +710,7 @@ pub async fn run_interactive() -> Result<()> {
 
 /// Entry point for interactive mode with optional hooks system
 pub async fn run_interactive_with_hooks(hooks: Option<Arc<hooks::HooksSystem>>) -> Result<()> {
-    run_interactive_with_config(hooks, vec![], vec![], Backend::Anthropic, None).await
+    run_interactive_with_config(hooks, vec![], vec![], Backend::Anthropic, None, None).await
 }
 
 /// Entry point for interactive mode with full configuration
@@ -702,9 +720,11 @@ pub async fn run_interactive_with_config(
     disallowed_tools: Vec<String>,
     backend: Backend,
     model_override: Option<String>,
+    azure_config: Option<AzureConfig>,
 ) -> Result<()> {
     let mut session =
-        InteractiveSession::with_hooks_and_backend(hooks, backend, model_override).await?;
+        InteractiveSession::with_hooks_and_backend(hooks, backend, model_override, azure_config)
+            .await?;
     session.allowed_tools = allowed_tools;
     session.disallowed_tools = disallowed_tools;
     session.run().await

--- a/crates/cli/src/print_mode.rs
+++ b/crates/cli/src/print_mode.rs
@@ -329,7 +329,10 @@ impl App {
             .as_deref()
             .map(|p| {
                 Backend::from_str_loose(p).ok_or_else(|| {
-                    anyhow::anyhow!("Unknown provider '{}'. Use 'anthropic', 'copilot', or 'azure'.", p)
+                    anyhow::anyhow!(
+                        "Unknown provider '{}'. Use 'anthropic', 'copilot', or 'azure'.",
+                        p
+                    )
                 })
             })
             .transpose()?
@@ -378,10 +381,29 @@ impl App {
                 }
             }
             Backend::AzureFoundry => {
-                return Err(anyhow::anyhow!(
-                    "Azure AI Foundry backend is not yet supported in RustyClawd CLI print mode. \
-                     Use it via the skwaq CLI."
-                ));
+                let endpoint = self
+                    .cli
+                    .azure_endpoint
+                    .as_deref()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Azure AI Foundry requires --azure-endpoint (or AZURE_FOUNDRY_ENDPOINT env var)"
+                        )
+                    })?;
+                let deployment = self
+                    .cli
+                    .azure_deployment
+                    .as_deref()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Azure AI Foundry requires --azure-deployment (or AZURE_OPENAI_DEPLOYMENT env var)"
+                        )
+                    })?;
+                let api_version = &self.cli.azure_api_version;
+                (
+                    Client::new_azure_foundry(endpoint, deployment, api_version)?,
+                    Backend::AzureFoundry,
+                )
             }
         };
 
@@ -554,15 +576,24 @@ impl App {
         let start_time = std::time::Instant::now();
 
         // Convert App runtime agents to tool-layer RuntimeAgentInfo
-        let runtime_agents_for_tools: std::collections::HashMap<String, rustyclawd_tools::RuntimeAgentInfo> =
-            self.runtime_agents.iter().map(|(name, def)| {
-                (name.clone(), rustyclawd_tools::RuntimeAgentInfo {
-                    prompt: def.prompt.clone(),
-                    model: def.model.clone(),
-                    allowed_tools: def.allowed_tools.clone(),
-                    disallowed_tools: def.disallowed_tools.clone(),
-                })
-            }).collect();
+        let runtime_agents_for_tools: std::collections::HashMap<
+            String,
+            rustyclawd_tools::RuntimeAgentInfo,
+        > = self
+            .runtime_agents
+            .iter()
+            .map(|(name, def)| {
+                (
+                    name.clone(),
+                    rustyclawd_tools::RuntimeAgentInfo {
+                        prompt: def.prompt.clone(),
+                        model: def.model.clone(),
+                        allowed_tools: def.allowed_tools.clone(),
+                        disallowed_tools: def.disallowed_tools.clone(),
+                    },
+                )
+            })
+            .collect();
 
         // Build the tool executor closure factory (shared by primary and fallback)
         macro_rules! make_tool_executor {

--- a/crates/cli/src/tool_executor.rs
+++ b/crates/cli/src/tool_executor.rs
@@ -508,6 +508,7 @@ mod tests {
             execution_context: rustyclawd_tools::ExecutionContext::NonInteractive,
             allowed_tools: vec![],
             disallowed_tools: vec![],
+            runtime_agents: std::collections::HashMap::new(),
         };
 
         // Missing required fields
@@ -536,6 +537,7 @@ mod tests {
             execution_context: rustyclawd_tools::ExecutionContext::NonInteractive,
             allowed_tools: vec![],
             disallowed_tools: vec![],
+            runtime_agents: std::collections::HashMap::new(),
         };
 
         // Wrong type for subagent_type (should be string)

--- a/crates/core/src/client/azure_foundry.rs
+++ b/crates/core/src/client/azure_foundry.rs
@@ -243,10 +243,7 @@ pub async fn create_message(
         req_builder = req_builder.header("Authorization", format!("Bearer {token}"));
     }
 
-    let response = req_builder
-        .json(&oai_request)
-        .send()
-        .await?;
+    let response = req_builder.json(&oai_request).send().await?;
 
     if !response.status().is_success() {
         return Err(ClientError::from_response(response).await);
@@ -284,10 +281,7 @@ pub async fn create_message_stream(
         req_builder = req_builder.header("Authorization", format!("Bearer {token}"));
     }
 
-    let response = req_builder
-        .json(&oai_request)
-        .send()
-        .await?;
+    let response = req_builder.json(&oai_request).send().await?;
 
     if !response.status().is_success() {
         return Err(ClientError::from_response(response).await);
@@ -376,11 +370,7 @@ mod tests {
 
     #[test]
     fn test_multi_deployment_round_robin() {
-        let auth = AzureAuth::new(
-            "https://x.azure.com",
-            "d1,d2,d3",
-            "2024-10-21",
-        );
+        let auth = AzureAuth::new("https://x.azure.com", "d1,d2,d3", "2024-10-21");
         assert_eq!(auth.deployment_count(), 3);
         let (url1, dep1) = auth.next_request_target();
         let (url2, dep2) = auth.next_request_target();
@@ -393,6 +383,7 @@ mod tests {
         assert!(url1.contains("/d1/"));
         assert!(url2.contains("/d2/"));
         assert!(url3.contains("/d3/"));
+        assert!(url4.contains("/d1/")); // wraps around
     }
 
     #[test]

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -36,9 +36,9 @@
 //! }
 //! ```
 
+pub mod azure_foundry;
 pub mod config;
 pub mod copilot;
-pub mod azure_foundry;
 pub mod error;
 pub mod request;
 pub mod response;
@@ -57,9 +57,9 @@ use secrecy::ExposeSecret;
 use std::future::Future;
 use std::time::Duration;
 
+pub use azure_foundry::AzureAuth;
 pub use config::{ApiKey, Backend, Config};
 pub use copilot::{CopilotAuth, CopilotModel};
-pub use azure_foundry::AzureAuth;
 pub use error::{ClientError, ClientResult};
 pub use request::{CreateMessageRequest, Metadata, Speed, ThinkingConfig};
 pub use response::{

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -69,7 +69,9 @@ pub use task::{
     TaskUpdateOutput, TaskUpdateParams, TaskUpdateTool,
 };
 pub use todo_write::TodoWriteTool;
-pub use types::{ExecutionContext, RuntimeAgentInfo, ToolContext, ToolEvent, ToolMetadata, ToolStream};
+pub use types::{
+    ExecutionContext, RuntimeAgentInfo, ToolContext, ToolEvent, ToolMetadata, ToolStream,
+};
 pub use web_fetch::WebFetchTool;
 pub use web_search::WebSearchTool;
 pub use write::WriteTool;


### PR DESCRIPTION
## Summary

Enables the Azure AI Foundry backend in both print mode and interactive mode, which were previously stubbed out with error messages.

## Changes

### CLI Arguments (cli_args.rs)
- `--azure-endpoint URL` with `AZURE_FOUNDRY_ENDPOINT` env var fallback
- `--azure-deployment NAME` with `AZURE_OPENAI_DEPLOYMENT` env var fallback  
- `--azure-api-version VERSION` (default: `2024-10-21`)
- Enabled clap `env` feature for environment variable integration

### Print Mode (print_mode.rs)
- Replaced error stub with actual `Client::new_azure_foundry()` call
- Validates endpoint and deployment are provided

### Interactive Mode (interactive.rs)
- Added `AzureConfig` struct for passing config through layers
- Replaced error stub with actual client creation
- Updated `run_interactive_with_config()` signature to accept `AzureConfig`

### App Runtime (app_runtime.rs)
- Builds `AzureConfig` from CLI args when Azure backend selected
- Passes config through to interactive mode

### Fixes
- `tool_executor.rs`: Added missing `runtime_agents` field to 2 test constructors
- `azure_foundry.rs`: Added url4 wrap-around assertion (fixes unused variable warning)
- Applied pending rustfmt formatting

## Usage
```bash
# Via CLI flags
rusty --provider azure --azure-endpoint https://myresource.openai.azure.com --azure-deployment gpt-51

# Via environment variables
export AZURE_FOUNDRY_ENDPOINT=https://myresource.openai.azure.com
export AZURE_OPENAI_DEPLOYMENT=gpt-51
rusty --provider azure
```

## Testing
- 6 azure_foundry core tests pass
- 771 CLI lib tests pass (4 pre-existing session_persistence failures)
- 399 tools tests pass