### PR TITLE
test: add unit coverage for AgentTool::execute (#514)

### DIFF
--- a/crates/tools/src/agent/tests.rs
+++ b/crates/tools/src/agent/tests.rs
@@ -1,7 +1,9 @@
 use super::*;
 use crate::agent_memory::MemoryScope;
-use crate::{ExecutionContext, Tool, ToolContext, ToolEvent};
+use crate::agent_registry::global_agent_registry;
+use crate::{ExecutionContext, RuntimeAgentInfo, Tool, ToolContext, ToolEvent};
 use futures::StreamExt;
+use std::collections::HashMap;
 use std::env;
 use std::path::PathBuf;
 use tempfile::TempDir;
@@ -346,4 +348,398 @@ async fn test_agent_with_frontmatter_background() {
     assert_eq!(fm.memory_scope, Some(MemoryScope::Project));
     assert!(prompt.contains("BG Agent"));
     assert!(!prompt.contains("background: true"));
+}
+
+// =============================================================================
+// AgentTool::execute coverage (issue #514)
+//
+// The tests below exercise the core `AgentTool::execute` Tool implementation
+// directly. They deterministically cover the network-free code paths:
+//   - missing agent definition -> Error event
+//   - worktree-isolation failure -> Error event
+//   - background mode early-return -> Result event (success path), including the
+//     runtime-agent (`--agents`) fallback, model resolution, frontmatter-forced
+//     background, and explicit resume IDs
+//   - tool metadata / capability flags
+//   - AgentParams (argument) deserialization, including malformed input
+//
+// No assertion here depends on the Claude API / provider boundary: error paths
+// return before any HTTP client is built, and background mode hands the network
+// call to a detached `tokio::spawn` task that the foreground stream (and thus
+// these tests) never awaits, so its outcome cannot influence any assertion. (If
+// real credentials happen to be present, that detached task may briefly start an
+// outbound request before the test runtime drops and cancels it; this is never
+// observed by the assertions.) Tests that depend on background mode being active
+// short-circuit when `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` forces foreground
+// execution, keeping them deterministic in any environment.
+// =============================================================================
+
+/// Build a `ToolContext` rooted at `cwd` with the given runtime agents.
+fn execute_ctx(cwd: PathBuf, runtime_agents: HashMap<String, RuntimeAgentInfo>) -> ToolContext {
+    ToolContext {
+        cwd,
+        debug: false,
+        metadata: serde_json::Value::Null,
+        execution_context: ExecutionContext::default(),
+        allowed_tools: vec![],
+        disallowed_tools: vec![],
+        runtime_agents,
+    }
+}
+
+/// Build `AgentParams` with sensible defaults for the fields a test does not care about.
+fn execute_params(
+    subagent_type: &str,
+    model: Option<&str>,
+    resume: Option<&str>,
+    run_in_background: bool,
+) -> AgentParams {
+    AgentParams {
+        description: "Test task".to_string(),
+        prompt: "Do the thing".to_string(),
+        subagent_type: subagent_type.to_string(),
+        model: model.map(str::to_string),
+        resume: resume.map(str::to_string),
+        run_in_background,
+        memory_scope: None,
+    }
+}
+
+/// Drive `AgentTool::execute` to completion and collect every emitted event.
+async fn run_execute(params: AgentParams, ctx: &ToolContext) -> Vec<ToolEvent<AgentOutput>> {
+    let tool = AgentTool;
+    let stream = tool
+        .execute(params, ctx)
+        .await
+        .expect("execute returns a stream");
+    stream.collect().await
+}
+
+fn first_error(events: &[ToolEvent<AgentOutput>]) -> Option<&str> {
+    events.iter().find_map(|e| match e {
+        ToolEvent::Error { message } => Some(message.as_str()),
+        _ => None,
+    })
+}
+
+fn first_result(events: &[ToolEvent<AgentOutput>]) -> Option<&AgentOutput> {
+    events.iter().find_map(|e| match e {
+        ToolEvent::Result(out) => Some(out),
+        _ => None,
+    })
+}
+
+fn has_progress(events: &[ToolEvent<AgentOutput>]) -> bool {
+    events
+        .iter()
+        .any(|e| matches!(e, ToolEvent::Progress { .. }))
+}
+
+/// Returns true when background mode is force-disabled by the environment.
+/// Tests that rely on background mode's deterministic early-return skip in that case.
+fn background_disabled() -> bool {
+    rustyclawd_core::is_background_tasks_disabled()
+}
+
+#[tokio::test]
+async fn test_execute_agent_not_found_yields_error() {
+    // Table of agent types that exist neither on disk nor as runtime agents.
+    let cases = ["nonexistent", "missing-agent", "no_such_agent"];
+    for agent_type in cases {
+        let temp_dir = TempDir::new().unwrap();
+        let ctx = execute_ctx(temp_dir.path().to_path_buf(), HashMap::new());
+        let events = run_execute(execute_params(agent_type, None, None, false), &ctx).await;
+
+        // Loading progress is always emitted before resolution is attempted.
+        assert!(
+            has_progress(&events),
+            "case `{agent_type}`: expected a progress event"
+        );
+        let err = first_error(&events)
+            .unwrap_or_else(|| panic!("case `{agent_type}`: expected an error event"));
+        assert!(
+            err.contains("not found"),
+            "case `{agent_type}`: error should mention `not found`, got: {err}"
+        );
+        // A failed load must not produce a result.
+        assert!(
+            first_result(&events).is_none(),
+            "case `{agent_type}`: must not yield a result on failure"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_execute_first_event_is_progress_then_error() {
+    // The streaming contract: progress is yielded before the failure is known.
+    let temp_dir = TempDir::new().unwrap();
+    let ctx = execute_ctx(temp_dir.path().to_path_buf(), HashMap::new());
+    let events = run_execute(execute_params("nonexistent", None, None, false), &ctx).await;
+
+    assert!(
+        matches!(events.first(), Some(ToolEvent::Progress { .. })),
+        "first event should be a progress update, got: {:?}",
+        events.first()
+    );
+    assert!(
+        matches!(events.last(), Some(ToolEvent::Error { .. })),
+        "last event should be the error, got: {:?}",
+        events.last()
+    );
+}
+
+#[tokio::test]
+async fn test_execute_worktree_isolation_failure_yields_error() {
+    let temp_dir = TempDir::new().unwrap();
+    // This path only fails (deterministically) when cwd is NOT inside a git repo.
+    // Skip if the temp dir is unexpectedly within one (keeps the test non-flaky).
+    if git2::Repository::discover(temp_dir.path()).is_ok() {
+        return;
+    }
+
+    let agents_dir = temp_dir.path().join(".claude").join("agents");
+    fs::create_dir_all(&agents_dir).await.unwrap();
+    fs::write(
+        agents_dir.join("wt_agent.md"),
+        "---\nisolation: worktree\n---\n# WT Agent\nYou run isolated.",
+    )
+    .await
+    .unwrap();
+
+    let ctx = execute_ctx(temp_dir.path().to_path_buf(), HashMap::new());
+    let events = run_execute(execute_params("wt_agent", None, None, false), &ctx).await;
+
+    let err = first_error(&events).expect("expected a worktree creation error");
+    assert!(
+        err.contains("worktree"),
+        "error should mention worktree isolation, got: {err}"
+    );
+    assert!(
+        first_result(&events).is_none(),
+        "worktree failure must not yield a result"
+    );
+}
+
+#[tokio::test]
+async fn test_execute_background_mode_returns_result_for_file_agent() {
+    if background_disabled() {
+        return; // environment forces foreground (network) execution; skip.
+    }
+    let temp_dir = TempDir::new().unwrap();
+    let cwd = setup_test_agent(&temp_dir).await; // writes .claude/agents/test_agent.md
+
+    let ctx = execute_ctx(cwd, HashMap::new());
+    let events = run_execute(execute_params("test_agent", None, None, true), &ctx).await;
+
+    assert!(
+        first_error(&events).is_none(),
+        "background mode should not error, got: {:?}",
+        first_error(&events)
+    );
+    let out = first_result(&events).expect("background mode yields a result immediately");
+    assert_eq!(out.agent_name, "test_agent");
+    // Background returns immediately; the response is fetched later via AgentOutput tool.
+    assert!(
+        out.response.is_empty(),
+        "background result response should be empty"
+    );
+    assert_eq!(
+        out.model, "claude-sonnet-4-6",
+        "default model should be sonnet"
+    );
+    assert!(
+        out.agent_id.starts_with("agent_test_agent_t"),
+        "agent_id should be generated for this agent type, got: {}",
+        out.agent_id
+    );
+    assert_eq!(out.tokens_used.total_tokens, 0);
+
+    // The agent should have been registered in the global registry.
+    let status = global_agent_registry().get_status(&out.agent_id).await;
+    assert!(
+        status.is_ok(),
+        "background agent should be registered, got: {:?}",
+        status
+    );
+}
+
+#[tokio::test]
+async fn test_execute_background_mode_runtime_agent_fallback() {
+    if background_disabled() {
+        return;
+    }
+    // No .claude/agents file exists; the agent is supplied via --agents runtime map.
+    let temp_dir = TempDir::new().unwrap();
+    let mut runtime_agents = HashMap::new();
+    runtime_agents.insert(
+        "runtime_agent".to_string(),
+        RuntimeAgentInfo {
+            prompt: "You are a runtime-defined agent.".to_string(),
+            model: None,
+            allowed_tools: vec![],
+            disallowed_tools: vec![],
+        },
+    );
+    let ctx = execute_ctx(temp_dir.path().to_path_buf(), runtime_agents);
+
+    let events = run_execute(execute_params("runtime_agent", None, None, true), &ctx).await;
+
+    assert!(
+        first_error(&events).is_none(),
+        "runtime fallback should not error"
+    );
+    let out = first_result(&events).expect("runtime agent should resolve and yield a result");
+    assert_eq!(out.agent_name, "runtime_agent");
+    assert!(out.agent_id.starts_with("agent_runtime_agent_t"));
+}
+
+#[tokio::test]
+async fn test_execute_background_mode_resolves_model() {
+    if background_disabled() {
+        return;
+    }
+    // (model input, expected resolved model id) end-to-end through execute.
+    let cases = [
+        (Some("haiku"), "claude-haiku-4-5-20251001"),
+        (Some("sonnet"), "claude-sonnet-4-6"),
+        (Some("opus"), "claude-opus-4-6"),
+        (Some("claude-custom-x"), "claude-custom-x"),
+        (None, "claude-sonnet-4-6"),
+    ];
+    for (input, expected) in cases {
+        let temp_dir = TempDir::new().unwrap();
+        let cwd = setup_test_agent(&temp_dir).await;
+        let ctx = execute_ctx(cwd, HashMap::new());
+
+        let events = run_execute(execute_params("test_agent", input, None, true), &ctx).await;
+        let out =
+            first_result(&events).unwrap_or_else(|| panic!("model `{input:?}`: expected a result"));
+        assert_eq!(
+            out.model, expected,
+            "model `{input:?}` should resolve to `{expected}`"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_execute_background_mode_honors_resume_id() {
+    if background_disabled() {
+        return;
+    }
+    let temp_dir = TempDir::new().unwrap();
+    let cwd = setup_test_agent(&temp_dir).await;
+    let ctx = execute_ctx(cwd, HashMap::new());
+
+    let events = run_execute(
+        execute_params("test_agent", None, Some("resume-abc-123"), true),
+        &ctx,
+    )
+    .await;
+
+    let out = first_result(&events).expect("expected a result");
+    // A supplied resume id is used verbatim instead of generating a new agent id.
+    assert_eq!(out.agent_id, "resume-abc-123");
+}
+
+#[tokio::test]
+async fn test_execute_frontmatter_forces_background() {
+    if background_disabled() {
+        return;
+    }
+    // Agent definition opts into background via frontmatter even though the
+    // caller passed run_in_background: false. execute must honor the frontmatter
+    // and return immediately with an empty-response result.
+    let temp_dir = TempDir::new().unwrap();
+    let agents_dir = temp_dir.path().join(".claude").join("agents");
+    fs::create_dir_all(&agents_dir).await.unwrap();
+    fs::write(
+        agents_dir.join("forced_bg.md"),
+        "---\nbackground: true\n---\n# Forced BG\nYou always run in background.",
+    )
+    .await
+    .unwrap();
+
+    let ctx = execute_ctx(temp_dir.path().to_path_buf(), HashMap::new());
+    let events = run_execute(execute_params("forced_bg", None, None, false), &ctx).await;
+
+    assert!(
+        first_error(&events).is_none(),
+        "forced background should not error"
+    );
+    let out = first_result(&events).expect("frontmatter background should yield a result");
+    assert_eq!(out.agent_name, "forced_bg");
+    assert!(
+        out.response.is_empty(),
+        "frontmatter-forced background result should have an empty response"
+    );
+}
+
+#[test]
+fn test_agent_tool_metadata_and_capabilities() {
+    let tool = AgentTool;
+    let meta = tool.metadata();
+    assert_eq!(meta.name, "Agent");
+    assert!(!meta.description.is_empty());
+    // Agent execution can mutate state via its own tool usage and is concurrency-safe.
+    assert!(!tool.is_read_only());
+    assert!(tool.is_concurrency_safe());
+}
+
+#[test]
+fn test_agent_params_deserialization() {
+    // Minimal valid payload: optional fields default.
+    let minimal = serde_json::json!({
+        "description": "d",
+        "prompt": "p",
+        "subagent_type": "t",
+    });
+    let params: AgentParams = serde_json::from_value(minimal).expect("minimal params deserialize");
+    assert_eq!(params.subagent_type, "t");
+    assert!(params.model.is_none());
+    assert!(params.resume.is_none());
+    assert!(!params.run_in_background);
+    assert!(params.memory_scope.is_none());
+
+    // Fully specified payload round-trips.
+    let full = serde_json::json!({
+        "description": "d",
+        "prompt": "p",
+        "subagent_type": "reviewer",
+        "model": "opus",
+        "resume": "agent_x",
+        "run_in_background": true,
+        "memory_scope": "project",
+    });
+    let params: AgentParams = serde_json::from_value(full).expect("full params deserialize");
+    assert_eq!(params.model.as_deref(), Some("opus"));
+    assert_eq!(params.resume.as_deref(), Some("agent_x"));
+    assert!(params.run_in_background);
+    assert_eq!(params.memory_scope.as_deref(), Some("project"));
+}
+
+#[test]
+fn test_agent_params_malformed_rejected() {
+    // Each payload is missing a required field or has a wrong type, and must fail.
+    let bad_payloads = [
+        // missing prompt
+        serde_json::json!({"description": "d", "subagent_type": "t"}),
+        // missing subagent_type
+        serde_json::json!({"description": "d", "prompt": "p"}),
+        // missing description
+        serde_json::json!({"prompt": "p", "subagent_type": "t"}),
+        // wrong type for run_in_background
+        serde_json::json!({
+            "description": "d", "prompt": "p", "subagent_type": "t",
+            "run_in_background": "yes"
+        }),
+        // not an object at all
+        serde_json::json!("just a string"),
+    ];
+    for (i, payload) in bad_payloads.iter().enumerate() {
+        let result: Result<AgentParams, _> = serde_json::from_value(payload.clone());
+        assert!(
+            result.is_err(),
+            "malformed payload #{i} should fail to deserialize: {payload}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes #514 — `AgentTool::execute` previously had **zero unit test coverage**; the 20 existing tests only exercised `AgentFrontmatter::parse` and the `resolve_model_id` / `generate_agent_id` / `load_agent_prompt` helpers, plus a single missing-prompt error case.

This PR adds **11 deterministic, network-free tests** that directly drive the core `AgentTool::execute` `Tool` implementation, taking the `agent` module from 20 → 31 active tests.

### Behaviors now covered (all network-free)

| Test | `execute` path exercised |
|------|--------------------------|
| `test_execute_agent_not_found_yields_error` | missing agent definition → `Error` event (table-driven, 3 names) |
| `test_execute_first_event_is_progress_then_error` | streaming contract: `Progress` before `Error` |
| `test_execute_worktree_isolation_failure_yields_error` | `isolation: worktree` in a non-git cwd → `Error` (git-repo guarded) |
| `test_execute_background_mode_returns_result_for_file_agent` | success path: background early-return `Result`, empty response, registry registration |
| `test_execute_background_mode_runtime_agent_fallback` | `--agents` runtime-agent fallback through `execute` |
| `test_execute_background_mode_resolves_model` | model resolution end-to-end (table-driven, 5 inputs) |
| `test_execute_background_mode_honors_resume_id` | explicit resume id used verbatim as `agent_id` |
| `test_execute_frontmatter_forces_background` | frontmatter `background: true` forces background mode |
| `test_agent_tool_metadata_and_capabilities` | `metadata()` / `is_read_only()` / `is_concurrency_safe()` |
| `test_agent_params_deserialization` | valid argument (de)serialization incl. defaults |
| `test_agent_params_malformed_rejected` | malformed/invalid arguments rejected (table-driven, 5 payloads) |

**No assertion crosses the Claude API / provider boundary.** Error paths return before any HTTP client is built; background mode hands the network call to a detached `tokio::spawn` task that the foreground stream never awaits, so its outcome cannot influence any assertion. Background-dependent tests short-circuit when `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` forces foreground execution, keeping them deterministic in any environment.

---

## Merge-ready evidence

### 1. Test scenarios — written, validated, run
The relevant "scenarios" for an internal Rust **library** unit-test change are the Rust `#[tokio::test]` / `#[test]` cases themselves, validated and run by `cargo test`:

```
$ cargo test -p rustyclawd-tools --lib agent::
running 32 tests
...
test result: ok. 31 passed; 0 failed; 1 ignored; 0 measured; 400 filtered out
```
Verified deterministic across repeat runs and with `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1`:
```
$ CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1 cargo test -p rustyclawd-tools --lib agent::tests::test_execute
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 424 filtered out
```

> Note on gadugi-test: the repo's `tests/e2e/scenarios/` are **TUI** scenarios driven by `@gadugi/agentic-test`, which require launching the binary against a live Claude API. They are not applicable to a library-only unit-test change (writing one would require crossing the network boundary these tests deliberately avoid). The installed `gadugi-test` v1.0.0 additionally does not validate the repo's existing scenario schema (`Scenario must have at least one agent`) — a pre-existing, unrelated tooling mismatch.

### 2. Docs
No user-facing surface changed. **Changed surface: `crates/tools/src/agent/tests.rs` only** — an internal `#[cfg(test)]` module. No public API, CLI, or behavior change; no docs update required.

### 3. quality-audit (≥3 SEEK→VALIDATE→FIX cycles, clean final)
- **Cycle 1** — Independent `code-review` agent read the full diff against `execute.rs`/`frontmatter.rs`/`agent_registry.rs`/`worktree_isolation.rs`, ran the suite 4× plus the env-var/worktree variants. Verdict: no significant issues; one **informational** accuracy nit — a header comment overstated the network guarantee. **FIX:** tightened the comment to precisely describe the detached-task behavior.
- **Cycle 2** — Re-ran `cargo fmt --all --check` (clean), `cargo clippy -p rustyclawd-tools --tests` (clean), full `agent::` suite (31 passed). No new findings.
- **Cycle 3 (final, clean)** — Verified determinism under `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` (8/8 execute tests pass) and 3× repeat runs. **Zero critical/high; zero medium correctness/security findings.**

Commits: `6db60e8` (tests + comment fix included).

### 4. CI — green locally (exact CI gates from `.github/workflows/ci.yml`)
| Job | Command | Result |
|-----|---------|--------|
| Format | `cargo fmt --all --check` | ✅ exit 0 |
| Lint | `cargo clippy --all-targets --all-features -- -D warnings` | ✅ exit 0 |
| Test | `cargo test --all-features` | ✅ exit 0 (workspace) |
| Build | `cargo build --release --all-features` | ✅ exit 0 |

The diff is entirely `#[cfg(test)]`, so the `Build` and `Brand Validation` jobs are definitionally unaffected. The separate `e2e-tests` workflow (TUI/gadugi, requires live API) is unrelated to this change; as on prior RustyClawd PRs it may be flaky for reasons independent of this diff — every check this change actually touches passes.

### 6. Focused diff
`crates/tools/src/agent/tests.rs` only — **+394 / −1** (the single deletion is the import line being extended). No production code touched; no unrelated edits.

---

## Follow-ups
Remaining test-coverage work in this goal lane: **#445** (TUI rendering / formatters / MCP types / tool schemas) and **#340** (recent feature PRs #331–#338).
