### PR TITLE
chore(security): SHA-pin Actions, lock deps, add cargo-deny audit gate, least-privilege GITHUB_TOKEN

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -11,7 +11,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -14,17 +17,17 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo test --all-features
 
   format:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
       - run: cargo fmt --all --check
@@ -33,22 +36,22 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
   branding:
     name: Brand Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Check for Claude branding in UI
         run: ./scripts/check-branding.sh
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Run branding validation tests
         run: cargo test --package rustyclawd-cli --test branding_test
 
@@ -56,7 +59,17 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build --release --all-features
+
+  cargo-deny:
+    name: Supply-chain audit (cargo-deny)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@dc3d73161fdc9d737a247c07ec4d259142348ee1 # cargo-deny
+      - name: Run cargo-deny (advisories + bans + licenses + sources)
+        run: cargo deny check

--- a/.github/workflows/claude-code-sync.yml
+++ b/.github/workflows/claude-code-sync.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build sync monitor
         run: cargo build --release --package rustyclawd-tools
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload ledger artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sync-ledger
           path: .claude/data/sync_ledger.json

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -14,22 +17,22 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@e2ba4a39dc7bf116c8a572366d98fadc69b818f5 # cargo-llvm-cov
 
       - name: Generate coverage report
         run: cargo llvm-cov --all-features --lcov --output-path lcov.info
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-report
           path: lcov.info

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:  # Allow manual triggers
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
@@ -14,13 +17,13 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       
       - name: Cache Cargo dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: |
             ~/.cargo/bin/
@@ -65,7 +68,7 @@ jobs:
       
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: e2e-test-results
           path: |
@@ -75,7 +78,7 @@ jobs:
       
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: e2e-test-logs-failure
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -39,13 +42,13 @@ jobs:
             target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.target }}
 
@@ -73,7 +76,7 @@ jobs:
           cd dist
           tar czf rusty-${{ matrix.target }}.tar.gz rusty-${{ matrix.target }}.exe
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: binaries-${{ matrix.target }}
           path: dist/rusty-${{ matrix.target }}.tar.gz
@@ -85,9 +88,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: release
           merge-multiple: true

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,104 @@
+# cargo-deny configuration — supply-chain audit gate for RustyClawd.
+#
+# Enforced in CI by the `cargo-deny` job in .github/workflows/ci.yml. The gate
+# checks four areas:
+#   * advisories — RustSec vulnerability / unsound / unmaintained advisories
+#   * bans       — banned crates and dependency-graph hygiene
+#   * licenses   — only permissively-licensed dependencies are allowed
+#   * sources    — crates may only come from crates.io or explicitly-pinned git
+#
+# Schema: cargo-deny v2 (https://embarkstudios.github.io/cargo-deny/).
+
+# ---------------------------------------------------------------------------
+# Advisories
+# ---------------------------------------------------------------------------
+[advisories]
+version = 2
+# Flag unmaintained advisories only for first-party (workspace) crates. The
+# transitive unmaintained crates in the tree (fxhash, proc-macro-error2,
+# ttf-parser) are pulled in by upstream dependencies and cannot be removed here.
+unmaintained = "workspace"
+# Warn (not fail) on yanked crates. The only yanked crates in the tree
+# (js-sys, wasm-bindgen) are wasm-target-only transitive deps that are never
+# compiled for the CLI binary; bumping the lockstep wasm-bindgen stack is out
+# of scope for this infra-only change.
+yanked = "warn"
+# Pre-existing advisories in the dependency tree at the time this gate was
+# introduced. They are deep transitive dependencies (rustls/aws-lc/octocrab,
+# pdf-extract, git2, …) with no drop-in fix available without major upstream
+# bumps, so they are tracked here rather than silently dropped. New advisories
+# NOT on this list will fail CI — that is the point of the gate. Remediating
+# this backlog (bumping the vulnerable transitive deps) is tracked as separate
+# follow-up work and is intentionally out of scope for this infra-only change.
+ignore = [
+    "RUSTSEC-2023-0071", # rsa 0.9.10 — Marvin timing sidechannel; no fixed release upstream
+    "RUSTSEC-2026-0007", # bytes 1.10.1 — integer overflow in BytesMut::reserve
+    "RUSTSEC-2026-0009", # time 0.3.45 — DoS via stack exhaustion
+    "RUSTSEC-2026-0044", # aws-lc-sys 0.37.1 — X.509 name-constraints bypass
+    "RUSTSEC-2026-0045", # aws-lc-sys 0.37.1 — AES-CCM tag verification timing sidechannel
+    "RUSTSEC-2026-0046", # aws-lc-sys 0.37.1 — PKCS7_verify cert chain bypass
+    "RUSTSEC-2026-0047", # aws-lc-sys 0.37.1 — PKCS7_verify signature bypass
+    "RUSTSEC-2026-0048", # aws-lc-sys 0.37.1 — CRL distribution-point scope logic error
+    "RUSTSEC-2026-0049", # rustls-webpki 0.103.8 — CRL distribution-point matching logic error
+    "RUSTSEC-2026-0097", # rand 0.9.2 — unsound with custom logger using rand::rng()
+    "RUSTSEC-2026-0098", # rustls-webpki 0.103.8 — URI name-constraints incorrectly accepted
+    "RUSTSEC-2026-0099", # rustls-webpki 0.103.8 — wildcard name-constraints incorrectly accepted
+    "RUSTSEC-2026-0104", # rustls-webpki 0.103.8 — reachable panic parsing CRLs
+    "RUSTSEC-2026-0183", # git2 0.20.4 — potential UB in Remote::list()
+    "RUSTSEC-2026-0184", # git2 0.20.4 — potential UB with Signature from buffer-created BlameHunk
+    "RUSTSEC-2026-0190", # anyhow 1.0.100 — unsoundness in Error::downcast_mut()
+]
+
+# ---------------------------------------------------------------------------
+# Licenses
+# ---------------------------------------------------------------------------
+[licenses]
+version = 2
+# Confidence required when inferring a license from a LICENSE file.
+confidence-threshold = 0.8
+# Permissive licenses present in the dependency tree. RustyClawd itself ships
+# under "MIT OR Apache-2.0"; everything here is OSI-approved and permissive.
+allow = [
+    "MIT",
+    "MIT-0",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "0BSD",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "OpenSSL",
+    "Zlib",
+    "BSL-1.0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+]
+
+# Per-crate license exceptions. html2md is GPL-3.0-or-later (copyleft); it is a
+# pre-existing transitive dependency. Scoping the allowance to this one crate
+# keeps the policy honest — GPL is NOT globally allowed for the project.
+[[licenses.exceptions]]
+name = "html2md"
+allow = ["GPL-3.0-or-later"]
+
+# ---------------------------------------------------------------------------
+# Bans
+# ---------------------------------------------------------------------------
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"
+
+# ---------------------------------------------------------------------------
+# Sources
+# ---------------------------------------------------------------------------
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+# Only the official crates.io registry is permitted.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# The single git dependency in the tree is a rev-pinned tui-textarea fork.
+allow-git = ["https://github.com/0xferrous/tui-textarea"]

--- a/tools/testing/Cargo.toml
+++ b/tools/testing/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustyclawd-continuous-tester"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [[bin]]
 name = "continuous_tester"


### PR DESCRIPTION
## Summary

Hardens the RustyClawd CI/release **supply chain** with no behavioural change to the build itself. Four areas, mirroring the proven hardening template already in place on `rysweet/Simard`:

1. **SHA-pin every GitHub Action** — all third-party actions across the 6 workflows are pinned to a full 40-char commit SHA (with a readable `# version` comment), eliminating mutable-tag hijack risk.
2. **Least-privilege `GITHUB_TOKEN`** — every workflow now declares an explicit top-level `permissions:` block; the default is `contents: read`, and write scopes are granted only where actually needed.
3. **`cargo-deny` audit gate** — a new required CI job runs `cargo deny check` (advisories + bans + licenses + sources), backed by a committed `deny.toml`.
4. **Locked / pinned dependencies** — confirmed `Cargo.lock` is committed and the sole git dependency is rev-pinned; the `sources` gate enforces this going forward.

### Action SHA pins

| Action | Pinned SHA | Version |
|---|---|---|
| actions/checkout | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| dtolnay/rust-toolchain | `29eef336d9b2848a0b548edc03f92a220660cdb8` | stable |
| Swatinem/rust-cache | `e18b497796c12c097a38f9edb9d0641fb99eee32` | v2 |
| actions/upload-artifact | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |
| actions/download-artifact | `d3f86a106a0bac45b974a628896c90dbdf5c8093` | v4.3.0 |
| actions/cache | `6f8efc29b200d32929f49075959781ed54ec270c` | v3.5.0 |
| taiki-e/install-action (llvm-cov) | `e2ba4a39dc7bf116c8a572366d98fadc69b818f5` | cargo-llvm-cov |
| taiki-e/install-action (deny) | `dc3d73161fdc9d737a247c07ec4d259142348ee1` | cargo-deny |

Each SHA is the commit the corresponding upstream tag currently resolves to (verified via `git ls-remote`); the shared pins match those already running green on Simard.

### Permissions (least privilege)

| Workflow | Top-level | Elevated scope (where) |
|---|---|---|
| auto-tag | `contents: write` | needed to push the release tag |
| ci | `contents: read` | — |
| claude-code-sync | `contents: read` | `issues: write` (files sync issues) |
| coverage | `contents: read` | — |
| e2e-tests | `contents: read` | — |
| release | `contents: read` | `contents: write` on the `release` job only |

### `deny.toml` design

- **sources** — only crates.io plus the one rev-pinned git fork (`0xferrous/tui-textarea`) are allowed; everything else is denied.
- **licenses** — permissive allow-list matching the actual tree; the single copyleft crate (`html2md`, GPL-3.0-or-later) is scoped via a per-crate exception so GPL is **not** globally allowed.
- **advisories** — the pre-existing RustSec backlog (deep transitive deps: aws-lc-sys, rustls-webpki, rsa, git2, anyhow, bytes, time, rand) is enumerated in `ignore` with per-line justification, so **new** advisories fail CI while the existing backlog is tracked. Remediating that backlog (bumping vulnerable transitive deps) is intentionally **out of scope** for this infra-only change and tracked as follow-up.

## Merge-ready evidence

**1. Test scenarios / validation.** This change touches only CI/build infrastructure (workflow YAML, `deny.toml`, one crate `license` field) — there is no user-facing or runtime code surface, so no new behavioural test scenarios apply. Validation performed instead:
- `actionlint 1.7.12` — **PASS** (0 issues) on all 6 workflows.
- `python -c yaml.safe_load` — **PASS** on all 6 workflows.
- `cargo deny check` — **PASS**: `advisories ok, bans ok, licenses ok, sources ok` (exit 0).

**2. Docs / changed surfaces.** No user-facing surface changed. Changed surfaces are internal infrastructure only: `.github/workflows/*.yml`, `deny.toml`, `tools/testing/Cargo.toml` (license field). Internal-only — no docs update required.

**3. Quality-audit (SEEK → VALIDATE → FIX), converged clean:**
- *Cycle 1* — baseline `cargo deny check`: advisories + licenses FAILED. FIX: added permissive license allow-list, `html2md` GPL exception, advisory `ignore` backlog, git-source allow-list.
- *Cycle 2* — re-run: yanked transitive (js-sys/wasm-bindgen) + unlicensed first-party `rustyclawd-continuous-tester` FAILED. FIX: `yanked = "warn"` (wasm-only deps), declared the crate's license.
- *Cycle 3* — re-run: all four checks green; `actionlint` clean; YAML clean. Zero outstanding critical/high or medium correctness/security findings.

**4. CI green.** All existing jobs are functionally unchanged (only action refs + permissions added); the new `cargo-deny` job passes locally. CI will confirm on this PR.

**6. Focused diff.** 6 workflow files + new `deny.toml` + a single `license` line in the internal testing crate. No unrelated edits; no source/logic changes; no lockfile churn.


---

## CI results (run 28405163917 / 28405163921)

| Check | Result |
|---|---|
| **Supply-chain audit (cargo-deny)** *(new)* | ✅ pass (13s) |
| Test | ✅ pass |
| Build | ✅ pass |
| Lint | ✅ pass |
| Format | ✅ pass |
| Coverage | ✅ pass |
| Brand Validation | ✅ pass |
| GitGuardian Security Checks | ✅ pass |
| e2e-tests | ⚠️ fail — **pre-existing, non-gating, unrelated to this change** |

**On the e2e-tests failure (criterion 4):** This check is red on `main`'s HEAD and on *every* recent run (consistently ~24–25 min `failure`). The failure here is in the live-agent scenario suite — `Agent Teams - Parallel Task Execution` → `Step 5 failed: Expected 'RustyClawd' not found` — i.e. a model-output assertion, **not** an infrastructure/workflow error. This PR's only effect on that workflow is SHA-pinning its actions and adding `permissions: contents: read`; the release build succeeded, the `rusty` binary ran, and all 29 scenarios executed exactly as on `main`. The repo has **no branch protection**, so e2e-tests is non-required (`mergeStateStatus: UNSTABLE`, `mergeable: MERGEABLE`) and the repository merges over it routinely. Remediating the agent E2E suite is out of scope for this supply-chain change.

Every check that this change can influence is green, including the newly-added supply-chain gate.
