### PR TITLE
ci(auto-tag): set git identity before creating annotated tag (fix 'empty ident name') — Closes #1108

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Create tag
         if: steps.check.outputs.exists == 'false'
         run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           TAG="v${{ steps.version.outputs.version }}"
           git tag -a "$TAG" -m "Auto-release $TAG"
           git push origin "$TAG"


### PR DESCRIPTION
## Summary
`Auto Tag on Merge` (`auto-tag.yml`) has failed on every default-branch run. The `Create tag` step runs `git tag -a` (an **annotated** tag), which requires a committer identity. GitHub runners have no default git identity, so the step aborted with `fatal: empty ident name ... not allowed` (exit 128).

Fix: configure the standard `github-actions[bot]` identity before `git tag -a`.

Closes #1108

## Root cause (confirmed)
Run [28406530827](https://github.com/rysweet/RustyClawd/actions/runs/28406530827) `tag` job:
```
git tag -a "$TAG" -m "Auto-release $TAG"
*** Please tell me who you are.
fatal: empty ident name (for <runner@...>) not allowed
##[error]Process completed with exit code 128.
```

## Diff (focused, 1 file)
```yaml
  - name: Create tag
    if: steps.check.outputs.exists == 'false'
    run: |
+     git config user.name 'github-actions[bot]'
+     git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
      TAG="v${{ steps.version.outputs.version }}"
      git tag -a "$TAG" -m "Auto-release $TAG"
      git push origin "$TAG"
```

## Merge-ready evidence
1. **Behavioral validation** — `Auto Tag on Merge` triggers only on `push: [main]` (no `pull_request`/`workflow_dispatch`), so it cannot execute on a PR branch. Validated the exact command sequence locally in a clean repo with **no** git identity: `git tag -a` reproduced `Author identity unknown / *** Please tell me who you are.`; after adding the two `git config` lines from this diff, the annotated tag was created successfully. `Cargo.toml` is `version = "0.1.1"` and only `v0.1.0` is tagged, so post-merge the `Create tag` step will actually run (not skip) and create/push `v0.1.1` — the fix is genuinely exercised on the next `main` run. For a CI-config-only change, executing the workflow commands is the authoritative behavioral test; no `gadugi-test` scenario applies (no Rust/runtime code changed).
2. **Docs/surfaces** — CI-internal change only; no user-facing surface changed. Internal-only, no docs update required.
3. **Quality audit** — Reviewed for correctness/security: identity uses the standard bot account; `permissions: contents: write` unchanged (already required for tag push); no new secrets. `actionlint .github/workflows/auto-tag.yml` → clean (exit 0). Local reproduction + fix verified.
4. **CI green** — Repo `ci.yml`/coverage checks on this PR are unaffected by a tag-workflow-only change. The target `Auto Tag on Merge` run is confirmable on `main` immediately post-merge (it will tag `v0.1.1`); this will be verified before closing out.
5. This description contains concrete evidence for criteria 1–4 and 6.
6. **Focused diff** — single file (`.github/workflows/auto-tag.yml`); no unrelated edits.