### PR TITLE
ci(e2e): degrade E2E job to skip-neutral on missing/invalid ANTHROPIC_API_KEY (#1109)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -57,14 +57,88 @@ jobs:
           RUST_BACKTRACE: 1
           RUSTYCLAWD_BIN: ${{ github.workspace }}/target/release/rusty
         run: |
-          if [ -z "$ANTHROPIC_API_KEY" ]; then
-            echo "⚠️ ANTHROPIC_API_KEY is not configured as a repository secret"
-            echo "E2E tests will be skipped. Configure the secret to enable automated testing."
-            echo "See: Settings → Secrets and variables → Actions → New repository secret"
+          set -uo pipefail
+          # GitHub Actions runs `run:` steps with `bash -e -o pipefail` by
+          # default, so a failing `runner.py | tee` pipeline would abort this
+          # step (errexit) before the graceful-degrade logic below can inspect
+          # the failure. Disable errexit and manage exit codes explicitly;
+          # keep pipefail so PIPESTATUS[0] reflects runner.py's real exit code.
+          set +e
+          # Mark the E2E job as skipped/neutral instead of failing the build.
+          # Provisioning a working ANTHROPIC_API_KEY is an operator action
+          # (tracked by issue #1109), not a code defect this job should
+          # red-line the default branch for. Emits a visible warning plus a
+          # job-summary notice, then exits 0.
+          skip_e2e() {
+            echo "::warning title=E2E tests skipped::$1"
+            {
+              echo "### ⚠️ E2E tests skipped (LLM credential unavailable)"
+              echo
+              echo "$1"
+              echo
+              echo "**Operator action required:** provision a valid \`ANTHROPIC_API_KEY\`"
+              echo "repository secret (Settings → Secrets and variables → Actions →"
+              echo "New repository secret) to enable automated end-to-end testing."
+              echo
+              echo "Tracking issue: #1109"
+            } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+            exit 0
+          }
+
+          # 1) Credential absent -> skip-neutral.
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            skip_e2e "ANTHROPIC_API_KEY is not configured as a repository secret, so no E2E scenario can authenticate against the LLM API."
+          fi
+
+          # 2) Run the scenarios, mirroring output to a log for artifact upload
+          #    and post-run authorization inspection.
+          cd tests/e2e/scenarios || exit 1
+          log_file="e2e-run.log"
+          python3 runner.py --verbose 2>&1 | tee "$log_file"
+          status=${PIPESTATUS[0]}
+
+          if [ "$status" -eq 0 ]; then
             exit 0
           fi
-          cd tests/e2e/scenarios
-          python3 runner.py --verbose
+
+          # 3) Present-yet-invalid credential: the secret exists but the LLM
+          #    provider rejects the model calls with an authorization error, so
+          #    scenarios that depend on a real model response die at their first
+          #    streaming request (e.g. "Streaming request failed: Unauthorized").
+          #    Treat that as skip-neutral rather than failing the default branch.
+          #
+          #    Why the marker alone is a safe, sufficient signal (no pass-count
+          #    guard needed):
+          #      * Anthropic auth is binary per credential -- a VALID key fails
+          #        NO request on auth; an INVALID/expired key fails EVERY request
+          #        on auth. So "Streaming request failed: <Unauthorized|Forbidden
+          #        |401|403>" (or an explicit provider auth-error type) can only
+          #        appear when the credential itself is bad. A genuine app
+          #        regression cannot make the provider return an auth error.
+          #      * When the credential is bad, no scenario can validate real LLM
+          #        behavior (a few may pass trivially without needing a model
+          #        response), so there is no meaningful regression signal to
+          #        mask -- real coverage resumes once an operator provisions a
+          #        valid key.
+          #    The match is deliberately tied to the client's own request-failure
+          #    marker / explicit provider auth-error types, NOT a bare "401" or
+          #    "Unauthorized" token that could appear incidentally in scenario
+          #    output (which would otherwise mask a genuine regression).
+          #
+          #    Assumption (holds for the current suite): no scenario legitimately
+          #    emits this marker with a VALID job credential (e.g. a negative-path
+          #    scenario that intentionally sends a bad per-request key or mocks a
+          #    401). If such a scenario is added later, tighten this to attribute
+          #    the marker to the failing scenario(s) rather than the aggregate log.
+          if grep -Eiq \
+               'streaming request failed:.*(unauthorized|forbidden|401|403)|authentication_error|invalid x-api-key' \
+               "$log_file"; then
+            skip_e2e "ANTHROPIC_API_KEY appears to be invalid or expired: the LLM provider rejected model calls with an authorization error, so E2E scenarios could not validate real behavior."
+          fi
+
+          # 4) Genuine failure unrelated to the LLM credential -> fail the job.
+          echo "::error title=E2E tests failed::One or more scenarios failed for reasons unrelated to the LLM credential."
+          exit "$status"
       
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## Summary

Fixes the CI-stewardship half of **#1109**: the `E2E Tests` job has red-lined `main` **continuously since ~2026-06-20**. Root cause is unambiguous — the `ANTHROPIC_API_KEY` repository secret is **present but invalid/expired**, so model-dependent scenarios die at their first model call with `Streaming request failed: Unauthorized`.

The old guard only handled an **empty** key (`[ -z "$ANTHROPIC_API_KEY" ]` → `exit 0`); a present-yet-invalid key sailed past it and failed the job, keeping `main` permanently red.

This makes the E2E job **degrade gracefully** so an operator-owned credential problem no longer red-lines `main`, while **genuine regressions still fail**:

| Situation | Behavior |
|---|---|
| Key absent | skip-neutral (`exit 0`) + `::warning::` + job summary |
| Key present-yet-invalid (job fails **and** LLM client auth-rejection marker present) | skip-neutral (`exit 0`) + warning + job summary |
| Job fails with **no** auth-rejection marker (real regression / infra) | job **fails** |

### Why the marker alone is a safe, sufficient signal
Anthropic auth is **binary per credential** — a valid key fails *no* request on auth; an invalid/expired key fails *every* request on auth. So the client's own marker `Streaming request failed: <Unauthorized|Forbidden|401|403>` (or an explicit provider auth-error type `authentication_error` / `invalid x-api-key`) can **only** appear when the credential is bad; a genuine app regression cannot make the provider return an auth error. When the credential is bad, no scenario can validate real LLM behavior (a few pass trivially), so **no meaningful regression signal is masked** — real coverage resumes once a valid key is provisioned. Detection is tied to the client's request-failure marker / explicit provider error types, **not** bare `401`/`Unauthorized` tokens that could appear incidentally.

`errexit` is explicitly disabled (`set +e`) because GitHub Actions runs steps with `bash -e -o pipefail`; otherwise the failing `runner.py | tee` pipeline would abort the step before the degrade logic runs. `pipefail` is kept so `PIPESTATUS[0]` captures `runner.py`'s real exit code.

> **#1109 stays OPEN.** This resolves the *CI-red*, but provisioning a valid `ANTHROPIC_API_KEY` remains an **operator action** outside code control.

---

## Merge-ready evidence

### 1. QA-team scenarios (`gadugi-test validate` / `run`)
Eight behavioral scenarios drive the **real extracted step script** under the **exact GitHub Actions shell** (`bash --noprofile --norc -e -o pipefail`), with a stubbed `runner.py` supplying representative logs. Each scenario self-asserts observed `(exit code, skipped?)` vs expected, so the step exit code is the gate.

```
$ gadugi-test validate -d ./scenarios --strict
✓ All 8 file(s) are valid   (Valid: 8, Invalid: 0)

$ gadugi-test run -d ./scenarios          # maxParallel=1, deterministic
PASS empty_key       exit=0 skip=yes   # missing key -> skip-neutral
PASS auth_all_fail   exit=0 skip=yes   # invalid key, 0 passed + auth marker -> skip
PASS auth_partial    exit=0 skip=yes   # invalid key, 3 passed/26 failed + marker (REAL CI shape) -> skip
PASS all_pass        exit=0 skip=no    # valid key, all pass -> success
PASS real_fail       exit=1 skip=no    # 28 pass + 1 non-auth failure -> job fails
PASS infra_fail      exit=1 skip=no    # all fail, no marker (tmux missing) -> not masked
PASS incidental_403  exit=1 skip=no    # 0 passed + bare "HTTP 403 Forbidden" fixture text, no marker -> fails
PASS bare_unauth     exit=1 skip=no    # some pass + bare "Unauthorized" word, no marker -> real bug fails
✓ Passed: 8  ✗ Failed: 0
```

**Iteration note (honest trail):** the first pushed revision required `0 passed` to skip. The real CI run then reported `Results: 3 passed, 26 failed` (a few scenarios pass trivially without a valid model response), so it correctly-but-unhelpfully stayed red. The `auth_partial` scenario reproduces that exact shape; the final logic keys off the definitive auth-rejection marker instead of the pass count. **Regression proof of the errexit fix:** the identical invalid-key case run against the pre-`set +e` script exits **1** and never skips under `bash -e -o pipefail`.

### 2. Docs / changed surfaces
Diff is **strictly scoped to `.github/workflows/e2e-tests.yml`** (no unrelated edits). The only changed surface is the **CI E2E job's pass/fail semantics on missing/invalid credentials** — CI-internal, not a user-facing runtime/API/CLI surface. It is self-documenting via inline comments, a `::warning::`, and a `$GITHUB_STEP_SUMMARY` notice referencing #1109. No user-facing docs require updates (internal-only justification).

### 3. quality-audit (≥3 SEEK→VALIDATE→FIX cycles, clean final)
- **C1:** independent review found **Critical** — `set -uo pipefail` didn't clear Actions' default `errexit`, so the degrade path was dead code (no-op). Plus **Medium/High** — auth grep too broad (bare tokens could mask a regression).
- **C2:** added `set +e`; tightened detection to the client auth-rejection marker + explicit provider error types; re-validated under the Actions shell + regression proof.
- **C3 (real-CI feedback):** live run showed `3 passed, 26 failed`; dropped the too-strict `0 passed` guard in favor of the definitive marker; independent review confirmed the marker cannot be produced by a valid credential and incidental bare tokens are correctly excluded (one **Low/latent** caveat documented inline: aggregate-log matching would need per-scenario attribution only if a future negative-path scenario intentionally emits auth markers — none exist today).
- Static analysis: `actionlint` OK; `shellcheck -s bash` clean.

### 4. CI green
The E2E workflow runs on this PR. With the invalid CI credential, the job now detects the auth rejection and exits **skip-neutral (green)** instead of failing — this PR's own green E2E check is the end-to-end proof. (All other checks — Build, Test, Coverage, Lint, Format, Brand, Supply-chain — already pass.)

### 6. Focused diff
Single file, `.github/workflows/e2e-tests.yml`, `Run E2E tests` step only. No other files touched.

Refs #1109
