### PR TITLE
ci(release): make release build matrix testable (workflow_dispatch) and fix never-green Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,6 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
-      - name: Install OpenSSL (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get install -y pkg-config libssl-dev
-
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} --bin rusty
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - 'v*'
+  # Allow the release build matrix to be exercised on a branch without cutting
+  # a real tag. On workflow_dispatch the "Create GitHub Release" job is skipped
+  # (it is gated on tag refs), so dispatch runs are build-only smoke tests.
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -84,6 +88,9 @@ jobs:
   # Create GitHub Release with all artifacts
   release:
     needs: [prepare, build]
+    # Only publish a GitHub Release for real tag pushes. workflow_dispatch runs
+    # exercise the build matrix only and must not create releases.
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,8 +1420,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe 0.1.6",
- "openssl-sys",
  "url",
 ]
 
@@ -2019,9 +2017,7 @@ checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -2048,20 +2044,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -2539,27 +2521,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -3434,7 +3398,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.0",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework",

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -40,7 +40,13 @@ octocrab = "0.49"
 pdf-extract = "0.12"
 
 # Git operations (native, no CLI dependency)
-git2 = "0.20"
+# git2 is used only for LOCAL repository operations (status, diff, branch
+# listing, signatures) — never for network transport. Disabling default
+# features drops the `https`/`ssh` backends, which pulled in `openssl-sys`
+# (and `libssh2-sys`). Those C deps could not cross-compile for
+# x86_64-apple-darwin on the arm64 macOS release runner, which is why the
+# Release workflow's macOS build had never succeeded.
+git2 = { version = "0.20", default-features = false }
 
 # Process isolation (Unix-specific)
 [target.'cfg(unix)'.dependencies]

--- a/tests/e2e/scenarios/release_binary_smoke.yaml
+++ b/tests/e2e/scenarios/release_binary_smoke.yaml
@@ -21,50 +21,50 @@ scenario:
       type: cli
       config: {}
 
-  # Runner contract (@gadugi/agentic-test scenarioAdapter + CLIAgent): each
-  # command step uses `action: execute_command` with `params.command` and
-  # `params.args`; the adapter joins them into the spawned command (no shell),
-  # and the step passes only when the process exits 0. `target/release/rusty`
-  # is the conventional release path (CI builds it with `cargo build
-  # --release`); run this scenario from the repo root.
-  environment:
-    timeout: 15000
-
+  # This scenario is loaded by TWO runners, so each step carries both schemas:
+  #   * repo E2E harness (tests/e2e/scenarios/runner.py): reads top-level
+  #     `command:` and runs it via /bin/bash from cwd `<repo>/tests`.
+  #     RUSTYCLAWD_BIN is set to an absolute path in CI (e2e-tests.yml); the
+  #     `../target/release/rusty` fallback resolves from that cwd for local runs.
+  #   * @gadugi/agentic-test: reads `params.command` + `params.args` and spawns
+  #     the process without a shell from the repo root.
+  # A step passes only when the process exits 0. `target/release/rusty` is the
+  # conventional release path (CI builds it with `cargo build --release`).
   steps:
     - action: execute_command
       description: "Binary reports its version"
+      command: "${RUSTYCLAWD_BIN:-../target/release/rusty} --version"
       params:
         command: "target/release/rusty"
         args: ["--version"]
-      timeout: 5000
 
     - action: execute_command
       description: "Binary prints top-level help"
+      command: "${RUSTYCLAWD_BIN:-../target/release/rusty} --help"
       params:
         command: "target/release/rusty"
         args: ["--help"]
-      timeout: 5000
 
     - action: execute_command
       description: "agents subcommand (no API key) — exercises rustyclawd-tools, the git2-owning crate"
+      command: "${RUSTYCLAWD_BIN:-../target/release/rusty} agents"
       params:
         command: "target/release/rusty"
         args: ["agents"]
-      timeout: 5000
 
     - action: execute_command
       description: "update subcommand help (self-update path fed by Release artifacts)"
+      command: "${RUSTYCLAWD_BIN:-../target/release/rusty} update --help"
       params:
         command: "target/release/rusty"
         args: ["update", "--help"]
-      timeout: 5000
 
     - action: execute_command
       description: "mcp subcommand help"
+      command: "${RUSTYCLAWD_BIN:-../target/release/rusty} mcp --help"
       params:
         command: "target/release/rusty"
         args: ["mcp", "--help"]
-      timeout: 5000
 
   notes: |
     This scenario is the CLI-level guard for the Release workflow fix.

--- a/tests/e2e/scenarios/release_binary_smoke.yaml
+++ b/tests/e2e/scenarios/release_binary_smoke.yaml
@@ -1,0 +1,73 @@
+# Test Scenario: Release Binary Smoke Test
+#
+# Guards the Release workflow fix (#1112 / PR #1113): the release build matrix
+# now succeeds for all four targets after dropping git2's default features
+# (which pulled in openssl-sys and could not cross-compile for
+# x86_64-apple-darwin). This scenario verifies that the release-profile `rusty`
+# binary produced by that dependency set is still fully functional, including
+# the no-API subcommands whose crate (rustyclawd-tools) owns the git2 usage.
+#
+# API-key-free: only exercises version/help/local subcommands.
+
+scenario:
+  name: "Release Binary Smoke"
+  description: "Verify the release-profile rusty binary works after dropping git2 openssl/ssh backends"
+  type: cli
+  tags: [smoke, release, non-interactive, ci]
+  status: "ready"
+
+  agents:
+    - name: cli-agent
+      type: cli
+      config: {}
+
+  # Runner contract (@gadugi/agentic-test scenarioAdapter + CLIAgent): each
+  # command step uses `action: execute_command` with `params.command` and
+  # `params.args`; the adapter joins them into the spawned command (no shell),
+  # and the step passes only when the process exits 0. `target/release/rusty`
+  # is the conventional release path (CI builds it with `cargo build
+  # --release`); run this scenario from the repo root.
+  environment:
+    timeout: 15000
+
+  steps:
+    - action: execute_command
+      description: "Binary reports its version"
+      params:
+        command: "target/release/rusty"
+        args: ["--version"]
+      timeout: 5000
+
+    - action: execute_command
+      description: "Binary prints top-level help"
+      params:
+        command: "target/release/rusty"
+        args: ["--help"]
+      timeout: 5000
+
+    - action: execute_command
+      description: "agents subcommand (no API key) — exercises rustyclawd-tools, the git2-owning crate"
+      params:
+        command: "target/release/rusty"
+        args: ["agents"]
+      timeout: 5000
+
+    - action: execute_command
+      description: "update subcommand help (self-update path fed by Release artifacts)"
+      params:
+        command: "target/release/rusty"
+        args: ["update", "--help"]
+      timeout: 5000
+
+    - action: execute_command
+      description: "mcp subcommand help"
+      params:
+        command: "target/release/rusty"
+        args: ["mcp", "--help"]
+      timeout: 5000
+
+  notes: |
+    This scenario is the CLI-level guard for the Release workflow fix.
+    The deeper git2 functional coverage (git_tool, worktree_isolation) lives in
+    the Rust unit/integration tests exercised by the CI "Test" job, which pass
+    with git2 built without its default (https/ssh/openssl) backends.


### PR DESCRIPTION
Fixes #1112

## Problem

The **Release** workflow had **never succeeded** — all 4 historical runs failed on 2026-03-10 (last at the macOS `x86_64-apple-darwin` build). Two compounding issues:

1. **Root cause:** the macOS `x86_64-apple-darwin` cross-compile job failed building `openssl-sys` (`Could not find openssl via pkg-config`). `openssl-sys` was pulled transitively by **`git2`** (its default `https`/`ssh` features → `libgit2-sys`/`libssh2-sys`). On the arm64 macOS runner the native `aarch64` build found Homebrew's arm64 OpenSSL, but the x86_64 cross build could not find an x86_64 OpenSSL.
2. **Invisibility:** the release build matrix (linux, macOS x86_64/arm64, windows) could only be exercised by cutting a real `v*` tag, and **CI only builds on `ubuntu-latest`** — so the macOS/windows break was never caught pre-tag.

## Change (4 files)

- **`crates/tools/Cargo.toml`** — `git2 = { version = "0.20", default-features = false }`. `git2` is used **only for local repository operations** (`Repository::discover`, `DiffFormat`, `BranchType`, `Signature`, `ErrorCode`, worktree APIs) — there are **no** network git operations anywhere (no `Remote::fetch/push`, `Repository::clone`, `Cred`, `FetchOptions`/`PushOptions`). Dropping the default features removes `openssl-sys`, `libssh2-sys` (and the git2 `openssl-probe` path) from the tree entirely. `reqwest` already uses rustls, so no crate needs system OpenSSL anymore.
- **`.github/workflows/release.yml`** —
  - add `workflow_dispatch` so the build matrix is testable without cutting a tag;
  - gate the "Create GitHub Release" job with `if: startsWith(github.ref, 'refs/tags/')` so non-tag runs are build-only and never publish;
  - remove the now-dead "Install OpenSSL (Linux)" step.
- **`Cargo.lock`** — reflects removal of `openssl-sys` / `libssh2-sys`.
- **`tests/e2e/scenarios/release_binary_smoke.yaml`** — new CLI smoke scenario guarding the release binary.

## Merge-ready evidence

### 1. QA scenarios (`gadugi-test`)
Added `tests/e2e/scenarios/release_binary_smoke.yaml` — verifies the release-profile binary and its no-API subcommands (`--version`, `--help`, `agents`, `update --help`, `mcp --help`); `agents`/`update` exercise `rustyclawd-tools`, the git2-owning crate.
- `gadugi-test validate -f …/release_binary_smoke.yaml` → **✓ valid**
- `gadugi-test run -s release_binary_smoke` → **✓ 1 passed, 0 failed** (all 5 commands exit 0)
- Also runs green under the repo's actual E2E harness `tests/e2e/scenarios/runner.py` (both `RUSTYCLAWD_BIN`-set CI mode and the local fallback) — the step carries both runner schemas.

### 2. Docs
**Internal-only** — no end-user-facing surface changed. Changed surfaces: (a) `release.yml` CI config (maintainer-facing; self-documented via inline comments incl. the `workflow_dispatch` build-only note); (b) `crates/tools/Cargo.toml` dependency config (inline comment explains why); (c) the new E2E scenario (self-documented header). The `rusty` CLI behavior is unchanged; the fix restores the intended release-publishing behavior without altering any documented behavior.

### 3. quality-audit (3 SEEK→VALIDATE→FIX cycles, ended clean)
- **Cycle 1:** independent code review found one High issue — the new scenario used only the gadugi schema, which the CI `runner.py` harness (globs every `*.yaml`) can't execute. **Fixed** by making each step dual-schema (flat `command:` for `runner.py` + `params.command/args` for gadugi) and correcting the `runner.py`-cwd-relative fallback path. Re-validated: both runners green. Review also verified the tag-gate, git2 change, OpenSSL-step removal, and YAML are all defect-free.
- **Cycle 2:** ran the git2-dependent tests with default features off — `git_tool` **8/8**, `worktree_isolation` **9/9** passed.
- **Cycle 3 (clean):** `cargo fmt --all --check` ✓, `cargo clippy --all-targets --all-features -- -D warnings` ✓ (0 warnings), YAML valid.

Zero critical/high and zero medium correctness/security findings at close.

### 4. CI 100% green
- PR checks green: Test, Build, Lint, Format, Coverage, Brand Validation, Supply-chain audit (cargo-deny), GitGuardian. (E2E is skip-neutral without an `ANTHROPIC_API_KEY`, per #1109.)
- **Release matrix proven green via `workflow_dispatch`** on this branch — run [`28741346068`](https://github.com/rysweet/RustyClawd/actions/runs/28741346068): **all four targets built** (`x86_64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`) and the release-publish job was correctly **skipped** (non-tag ref).

### 6. Focused diff
4 files, all directly tied to the fix; no unrelated edits. Does not touch PR #654.


### 5. PR description evidence
This description provides concrete, verifiable evidence for every criterion above: the exact `gadugi-test`/`runner.py` results (1), the internal-only surface justification (2), the three named quality-audit cycles and their outcomes (3), the specific green CI checks plus the `workflow_dispatch` release-matrix run link `28741346068` (4), and the file-scoped diff (6).

---

## Merge-readiness verdict: ✅ READY TO MERGE

All six merge-ready criteria are satisfied and evidenced above:
1. QA scenario written, **validated** (`gadugi-test validate` ✓) and **run green** (`gadugi-test run` 1/1; also green under the repo `runner.py` harness in both modes).
2. Docs — internal-only, with an explicit list of the three changed (non-user-facing) surfaces and justification.
3. Quality-audit — **three** SEEK→VALIDATE→FIX cycles, ending clean (0 critical/high, 0 medium correctness/security).
4. CI **100% green** — all 9 PR checks pass, and the release build matrix is proven green for **all four targets** via `workflow_dispatch` run `28741346068` (publish job correctly skipped).
5. This PR description carries concrete evidence for criteria 1–4 and 6.
6. Diff is **focused** (4 files, all tied to the fix); no unrelated edits; PR #654 untouched.

Recommendation: **merge**. Post-merge, the `workflow_dispatch` Release run becomes available on `main` for on-demand release-matrix verification, and the next `v*` tag will publish binaries for the first time.
