### PR TITLE
fix(deps): bump crossbeam-epoch 0.9.18 -> 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Remediates **RUSTSEC-2026-0204** by pinning `crossbeam-epoch` from **0.9.18 → 0.9.20** in `Cargo.lock`.

The advisory ([RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204)) reports an *invalid pointer dereference* in `crossbeam-epoch`'s `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid. Fixed upstream in `crossbeam-epoch >= 0.9.20` ([crossbeam-rs/crossbeam#1276](https://github.com/crossbeam-rs/crossbeam/pull/1276)).

This is the newest advisory in the tree and is **not** on the `deny.toml` pre-existing ignore backlog, so it was failing the `cargo-deny` CI gate on `main`. This PR clears it.

### Change
```
cargo update -p crossbeam-epoch --precise 0.9.20
```
Targeted single-crate pin only — **no** wholesale `cargo update`.

```diff
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
```

---

## Merge-ready criteria

### 1. QA / validation (qa-team)
This is a `Cargo.lock`-only transitive-dependency pin with **zero** source, behavior, API, or CLI change, so no new `gadugi-test` scenario is applicable — there is no new user-facing behavior to script. Functional regression is covered by the existing CI **Test** job (`cargo test --all-features`). The advisory-specific validation is `cargo deny check advisories`:

```
$ cargo deny check advisories
advisories ok
```
`grep RUSTSEC-2026-0204` of the advisory output → **0 matches** (advisory cleared). `crossbeam-epoch` in `Cargo.lock` is now `0.9.20` (`>= 0.9.20`).

Full supply-chain gate (exactly what CI runs) also passes locally:
```
$ cargo deny check
advisories ok, bans ok, licenses ok, sources ok   # exit 0
```

### 2. Documentation
**N/A — internal-only justification.** This bumps an internal transitive dependency in the lockfile. No public API, CLI surface, configuration, or user-facing documentation is affected. Changed surface: `Cargo.lock` only.

### 3. quality-audit (>=3 SEEK -> VALIDATE -> FIX cycles, clean final)
- **Cycle 1 — Scope.** SEEK: is the diff minimal and unrelated-change-free? VALIDATE: `git diff` is 2 lines in `Cargo.lock` (version + checksum) for `crossbeam-epoch` only; no `Cargo.toml`, source, or workflow edits. FIX: none needed.
- **Cycle 2 — Correctness.** SEEK: does the pin actually satisfy the advisory and still resolve/compile? VALIDATE: `crossbeam-epoch 0.9.20` (advisory requires `>=0.9.20`); `cargo build` finished successfully (exit 0). FIX: none needed.
- **Cycle 3 — Security / advisory closure.** SEEK: is RUSTSEC-2026-0204 fully cleared with no new advisory introduced? VALIDATE: `cargo deny check advisories` = `advisories ok`, 0 references to RUSTSEC-2026-0204; full `cargo deny check` = all four areas ok (exit 0), no new advisory surfaced. FIX: none needed.
- **Final cycle:** clean — zero critical/high, zero medium correctness/security findings.

### 4. CI
All required CI checks are green on the PR head commit. Per-check green runs:

| Check | Result | Run |
| --- | --- | --- |
| Build | ✅ pass | https://github.com/rysweet/RustyClawd/actions/runs/28831389817/job/85505840846 |
| Test | ✅ pass | https://github.com/rysweet/RustyClawd/actions/runs/28831389817/job/85505840842 |
| Coverage | ✅ pass | https://github.com/rysweet/RustyClawd/actions/runs/28831389771/job/85505840709 |
| Format | ✅ pass | https://github.com/rysweet/RustyClawd/actions/runs/28831389817/job/85505840843 |
| Lint | ✅ pass | https://github.com/rysweet/RustyClawd/actions/runs/28831389817/job/85505840860 |
| Supply-chain audit (cargo-deny) | ✅ pass | https://github.com/rysweet/RustyClawd/actions/runs/28831389817/job/85505840849 |
| Brand Validation | ✅ pass | https://github.com/rysweet/RustyClawd/actions/runs/28831389817/job/85505840867 |
| e2e-tests | ✅ pass | https://github.com/rysweet/RustyClawd/actions/runs/28831389844/job/85505840924 |
| GitGuardian Security Checks | ✅ pass | https://dashboard.gitguardian.com |

This PR specifically turns the `cargo-deny` supply-chain gate from red → green on `main`.

### 5. Evidence completeness
This description contains concrete, reproducible evidence for criteria 1–4 and 6 (command outputs, per-check CI run links, and the full diff). All six criteria are documented above and below.

### 6. Focused diff
Single file, 2 lines: `Cargo.lock` (`crossbeam-epoch` version + checksum). No unrelated edits.

---

## Verdict

**Ready to merge.** All six merge-ready criteria are satisfied with substantive evidence:

- **QA** — `cargo deny check advisories` → `advisories ok`; RUSTSEC-2026-0204 cleared (0 matches); functional regression covered by the green CI **Test** job.
- **Documentation** — N/A with internal-only justification (lockfile-only transitive bump; no user-facing surface).
- **Quality-audit** — 3 SEEK→VALIDATE→FIX cycles (scope, correctness, security closure); clean final cycle (zero critical/high, zero medium correctness/security).
- **CI** — all 9 required checks green (per-check run links above); the `cargo-deny` gate flips red → green.
- **Evidence** — this body documents criteria 1–4 and 6 with reproducible commands and links.
- **Scope** — focused 2-line `Cargo.lock` diff, no unrelated edits.

No required reviewers on the repo; PR is `MERGEABLE`/`CLEAN` on base `main` → authorized for gated self-merge.

