### PR TITLE
Fix RUSTSEC-2026-0204 crossbeam-epoch advisory

### DIFF
--- a/agentic-test.config.yaml
+++ b/agentic-test.config.yaml
@@ -1,0 +1,26 @@
+# Agentic test configuration for repository-local QA scenarios.
+execution:
+  maxParallel: 1
+  defaultTimeout: 30000
+  continueOnFailure: false
+  maxRetries: 0
+  retryDelay: 1000
+
+cli:
+  executablePath: cargo
+  workingDirectory: ./
+  defaultTimeout: 30000
+  environment: {}
+  captureOutput: true
+
+logging:
+  level: info
+  console: true
+  format: structured
+
+reporting:
+  outputDir: ./target/agentic-test-reports
+  formats:
+    - json
+  includeScreenshots: false
+  includeLogs: true

--- a/crates/cli/src/session_persistence.rs
+++ b/crates/cli/src/session_persistence.rs
@@ -32,6 +32,8 @@
 //! persistence.auto_save()?;
 //! ```
 
+#[cfg(test)]
+use crate::checkpoint::storage::CheckpointStorage;
 use crate::checkpoint::{
     loader::SessionLoader,
     saver::SessionSaver,
@@ -91,11 +93,26 @@ impl SessionPersistence {
         let session_id = session_id.into();
         let session = Session::new(session_id, MAX_CHECKPOINTS);
 
+        #[cfg(not(test))]
         let saver = SessionSaver::with_default_storage()
             .context("Failed to initialize checkpoint storage")?;
 
+        #[cfg(not(test))]
         let loader = SessionLoader::with_default_storage()
             .context("Failed to initialize checkpoint loader")?;
+
+        #[cfg(test)]
+        let (saver, loader) = {
+            let storage = CheckpointStorage::new(
+                std::env::temp_dir()
+                    .join("rustyclawd-session-persistence-tests")
+                    .join(std::process::id().to_string()),
+            );
+            (
+                SessionSaver::new(storage.clone()),
+                SessionLoader::new(storage),
+            )
+        };
 
         Ok(Self {
             session,
@@ -386,14 +403,18 @@ impl SessionPersistence {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static SESSION_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     fn temp_session_id() -> String {
         format!(
-            "test-session-{}",
+            "test-session-{}-{}",
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
-                .as_nanos()
+                .as_nanos(),
+            SESSION_COUNTER.fetch_add(1, Ordering::Relaxed)
         )
     }
 

--- a/crates/cli/tests/notification_integration_tests.rs
+++ b/crates/cli/tests/notification_integration_tests.rs
@@ -85,10 +85,7 @@ fn create_test_context(event: HookEvent) -> HookContext {
     HookContext::for_session(
         "test-session-123".to_string(),
         "/tmp/test-transcript.log".to_string(),
-        std::env::current_dir()
-            .unwrap()
-            .to_string_lossy()
-            .to_string(),
+        env!("CARGO_MANIFEST_DIR").to_string(),
         "auto".to_string(),
         event,
     )
@@ -99,10 +96,7 @@ fn create_notification_context(notification_type: NotificationType) -> HookConte
     HookContext::for_notification(
         "test-session-123".to_string(),
         "/tmp/test-transcript.log".to_string(),
-        std::env::current_dir()
-            .unwrap()
-            .to_string_lossy()
-            .to_string(),
+        env!("CARGO_MANIFEST_DIR").to_string(),
         "ask".to_string(),
         notification_type,
     )

--- a/crates/tools/src/git_tool/mod.rs
+++ b/crates/tools/src/git_tool/mod.rs
@@ -111,10 +111,50 @@ mod tests {
     use super::*;
     use crate::Tool;
     use futures::StreamExt;
+    use serial_test::serial;
+    use std::ffi::OsString;
     use std::process::Command;
     use tempfile::TempDir;
 
-    fn setup_git_repo() -> TempDir {
+    struct GitEnvGuard {
+        saved: Vec<(&'static str, Option<OsString>)>,
+    }
+
+    impl GitEnvGuard {
+        fn new() -> Self {
+            let vars = [
+                "GIT_DIR",
+                "GIT_WORK_TREE",
+                "GIT_INDEX_FILE",
+                "GIT_OBJECT_DIRECTORY",
+                "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+            ];
+            let saved = vars
+                .into_iter()
+                .map(|var| {
+                    let value = std::env::var_os(var);
+                    std::env::remove_var(var);
+                    (var, value)
+                })
+                .collect();
+            Self { saved }
+        }
+    }
+
+    impl Drop for GitEnvGuard {
+        fn drop(&mut self) {
+            for (var, value) in &self.saved {
+                if let Some(value) = value {
+                    std::env::set_var(var, value);
+                } else {
+                    std::env::remove_var(var);
+                }
+            }
+        }
+    }
+
+    fn setup_git_repo() -> (TempDir, GitEnvGuard) {
+        let git_env = GitEnvGuard::new();
         let temp_dir = TempDir::new().unwrap();
 
         // Initialize git repo
@@ -152,12 +192,13 @@ mod tests {
             .output()
             .expect("Failed to commit");
 
-        temp_dir
+        (temp_dir, git_env)
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_git_status_clean() {
-        let temp_dir = setup_git_repo();
+        let (temp_dir, _git_env) = setup_git_repo();
 
         let tool = GitTool;
         let params = GitParams {
@@ -186,8 +227,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_git_status_with_changes() {
-        let temp_dir = setup_git_repo();
+        let (temp_dir, _git_env) = setup_git_repo();
 
         // Add a new untracked file
         std::fs::write(temp_dir.path().join("new_file.txt"), "new content").unwrap();
@@ -230,8 +272,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_git_log() {
-        let temp_dir = setup_git_repo();
+        let (temp_dir, _git_env) = setup_git_repo();
 
         let tool = GitTool;
         let params = GitParams {
@@ -265,8 +308,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_git_branches() {
-        let temp_dir = setup_git_repo();
+        let (temp_dir, _git_env) = setup_git_repo();
 
         let tool = GitTool;
         let params = GitParams {
@@ -299,8 +343,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_git_current_branch() {
-        let temp_dir = setup_git_repo();
+        let (temp_dir, _git_env) = setup_git_repo();
 
         let tool = GitTool;
         let params = GitParams {
@@ -330,8 +375,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_git_commit_info() {
-        let temp_dir = setup_git_repo();
+        let (temp_dir, _git_env) = setup_git_repo();
 
         let tool = GitTool;
         let params = GitParams {
@@ -365,8 +411,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_git_diff() {
-        let temp_dir = setup_git_repo();
+        let (temp_dir, _git_env) = setup_git_repo();
 
         // Modify the existing file
         std::fs::write(temp_dir.path().join("README.md"), "# Modified\nNew line\n").unwrap();
@@ -410,7 +457,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_git_not_a_repo() {
+        let _git_env = GitEnvGuard::new();
         let temp_dir = TempDir::new().unwrap();
         // Don't initialize git repo
 

--- a/scenarios/rustsec-2026-0204-crossbeam-epoch.yaml
+++ b/scenarios/rustsec-2026-0204-crossbeam-epoch.yaml
@@ -1,0 +1,26 @@
+id: rustsec-2026-0204-crossbeam-epoch
+name: RUSTSEC-2026-0204 crossbeam-epoch remediation
+description: Confirms the RustyClawd lockfile resolves crossbeam-epoch to the fixed advisory version.
+version: 1.0.0
+priority: HIGH
+interface: CLI
+prerequisites: []
+tags: [security, rustsec, dependencies]
+agents:
+  - name: dependency-agent
+    type: cli
+    config:
+      workingDirectory: ./
+steps:
+  - name: Inspect locked crossbeam-epoch version
+    agent: dependency-agent
+    action: execute
+    description: Inspect the locked reverse dependency tree for crossbeam-epoch.
+    params:
+      command: cargo tree -i crossbeam-epoch --locked
+    expect:
+      type: contains
+      patterns:
+        - crossbeam-epoch v0.9.20
+estimatedDuration: 30
+enabled: true


### PR DESCRIPTION
## Summary

Fixes RUSTSEC-2026-0204 by updating the locked `crossbeam-epoch` dependency from 0.9.18 to 0.9.20.

Also includes narrow CI-enablement test infrastructure needed by the current hook/CI environment:
- test isolation for cwd/git-hook environment races
- a focused gadugi QA scenario that verifies the lockfile resolves `crossbeam-epoch v0.9.20`

## Merge-ready verdict

**Ready to merge.** Rationale: the advisory is remediated, the diff is focused, required QA and quality-audit evidence is complete, and every GitHub check is green on head SHA `15d18dbaa203c252a5e6dd5618957170f41d3cbf`.

## Merge-ready evidence

1. **qa-team/gadugi-test**
   - Added `scenarios/rustsec-2026-0204-crossbeam-epoch.yaml`
   - `gadugi-test validate -d scenarios --strict` passed
   - `gadugi-test run -d scenarios -c agentic-test.config.yaml --scenario rustsec-2026-0204-crossbeam-epoch` passed (1 passed, 0 failed)

2. **Docs / user-facing surface**
   - No user-facing runtime behavior changed. This is an internal dependency lockfile/security remediation plus deterministic test/QA infrastructure, so no user docs were updated.

3. **Quality audit: 3 SEEK -> VALIDATE -> FIX cycles**
   - Cycle 1: SEEK advisory path (`moka -> crossbeam-epoch`) -> VALIDATE `cargo deny check advisories` reported RUSTSEC-2026-0204 before update -> FIX `cargo update -p crossbeam-epoch --precise 0.9.20`.
   - Cycle 2: SEEK CI/pre-commit readiness -> VALIDATE hook/CI exposed current-environment test isolation races -> FIX deterministic session persistence and git-hook env isolation in tests.
   - Cycle 3: SEEK final focused diff/review -> VALIDATE `git diff --check`, code-review agent, final fmt/clippy/test/build/gadugi/advisory checks -> FIX none required. Final focused review found no high-confidence correctness/security findings.

4. **CI 100% green with run links**
   - [Test](https://github.com/rysweet/RustyClawd/actions/runs/29008785319/job/86086879187) — passed
   - [Coverage](https://github.com/rysweet/RustyClawd/actions/runs/29008785262/job/86086879087) — passed
   - [E2E Tests / e2e-tests](https://github.com/rysweet/RustyClawd/actions/runs/29008785295/job/86086879234) — passed
   - [Format](https://github.com/rysweet/RustyClawd/actions/runs/29008785319/job/86086879203) — passed
   - [Lint](https://github.com/rysweet/RustyClawd/actions/runs/29008785319/job/86086879226) — passed
   - [Brand Validation](https://github.com/rysweet/RustyClawd/actions/runs/29008785319/job/86086879230) — passed
   - [Build](https://github.com/rysweet/RustyClawd/actions/runs/29008785319/job/86086879267) — passed
   - [Supply-chain audit (cargo-deny)](https://github.com/rysweet/RustyClawd/actions/runs/29008785319/job/86086879227) — passed
   - [GitGuardian Security Checks](https://dashboard.gitguardian.com) — passed

5. **Local validation evidence**
   - `cargo fmt --all --check` — passed
   - `cargo clippy --all-targets --all-features -- -D warnings` — passed
   - `cargo test --all-features` — passed
   - `cargo build --release --all-features` — passed
   - `cargo build --release --bin rusty` — passed

6. **Advisory validation**
   - `cargo deny check advisories` passes and no longer reports RUSTSEC-2026-0204.
   - `cargo tree -i crossbeam-epoch --locked` shows `crossbeam-epoch v0.9.20`.

7. **Focused diff**
   - Dependency remediation: `Cargo.lock` updates `crossbeam-epoch` to 0.9.20.
   - Additional edits are limited to deterministic test isolation and the focused gadugi scenario/config needed to prove the remediation.

## Linked issue

No existing open or closed RustyClawd issue matched `RUSTSEC-2026-0204`, `crossbeam-epoch`, or `crossbeam` before PR creation.
